### PR TITLE
remove shapeprop calls in migraphx backend

### DIFF
--- a/py/torch_migraphx/dynamo/lower_dynamo.py
+++ b/py/torch_migraphx/dynamo/lower_dynamo.py
@@ -65,8 +65,7 @@ def lower_aten_to_mgx(gm: torch.fx.GraphModule,
     del gm
 
     for name, mod in optim_gm.named_children():
-        partition_inputs = get_partition_inputs(optim_gm, mod,
-                                                example_inputs)
+        partition_inputs = get_partition_inputs(optim_gm, mod, example_inputs)
         if verbose:
             print_graph_info(name, mod, partition_inputs)
 
@@ -91,8 +90,6 @@ def lower_subgraph(module: torch.fx.GraphModule,
     Returns:
         MGXModule: Callable module that executes graph via MIGraphX
     """
-
-    ShapeProp(module).propagate(*inputs)
 
     verbose = kwargs['verbose'] if 'verbose' in kwargs else False
     fp16 = kwargs['fp16'] if 'fp16' in kwargs else False

--- a/py/torch_migraphx/dynamo/passes/pass_manager.py
+++ b/py/torch_migraphx/dynamo/passes/pass_manager.py
@@ -37,11 +37,11 @@ from .freezing import constant_fold
 from torch.fx.passes.shape_prop import ShapeProp
 from torch.fx.experimental.const_fold import split_const_subgraphs
 
+
 # TODO: Use torch fx pass manager to run the below passes
 def run_aten_passes(gm: torch.fx.GraphModule,
                     inputs: Sequence[torch.Tensor],
                     verbose: bool = False):
-    ShapeProp(gm).propagate(*inputs)
     gm = remove_new_const_ops(gm)
     gm = remove_view_ops(gm)
     gm = remove_const_like_ops(gm)


### PR DESCRIPTION
Removing propagate calls as dynamo already populates the `meta` field for each node in the generated graph. This resolves issue seen in #29 