### PR TITLE
Perform interpretation/conversion on cpu

### DIFF
--- a/examples/fx/lowering_example.py
+++ b/examples/fx/lowering_example.py
@@ -11,15 +11,13 @@ import torchvision.models as models
 from torch_migraphx.fx import lower_to_mgx
 
 if __name__ == '__main__':
-    model = models.resnet50().cuda()
-
-    sample_inputs = [torch.randn(16, 3, 244, 244).cuda()]
-
-    mgx_model = lower_to_mgx(model, sample_inputs, verbose_log=True)
-
-    mgx_out = mgx_model(*sample_inputs)
-
+    model = models.resnet50().eval()
+    sample_inputs = [torch.randn(16, 3, 244, 244)]
     torch_out = model(*sample_inputs)
 
-    assert torch.allclose(mgx_out, torch_out, rtol=5e-3, atol=1e-2), 'Failed!'
+    mgx_model = lower_to_mgx(model, sample_inputs, verbose_log=True)
+    mgx_out = mgx_model(*sample_inputs)
+    
+
+    assert torch.allclose(mgx_out.cpu(), torch_out, rtol=5e-3, atol=1e-2), 'Failed!'
     print('Success!')

--- a/py/torch_migraphx/fx/lower.py
+++ b/py/torch_migraphx/fx/lower.py
@@ -52,9 +52,9 @@ logger = logging.getLogger(__name__)
 Input = Sequence[Any]
 
 
-def to_device(x):
+def to_device(x, device):
     if isinstance(x, torch.Tensor):
-        return x.cuda()
+        return x.to(device)
     elif isinstance(x, (tuple, list)):
         return [to_device(y) for y in x]
     else:
@@ -86,8 +86,8 @@ def lower_to_mgx(module: nn.Module,
     Returns:
         A SplitModule object containing MGXModule (lowered graphs) and torch.fx.GraphModule (unsupported graphs) objects.
     """
-    module = module.cuda().eval()
-    input = [to_device(x) for x in input]
+    module = module.cpu().eval()
+    input = [to_device(x, "cpu") for x in input]
     lower_setting = LowerSetting(
         lower_precision=lower_precision,
         verbose_log=verbose_log,

--- a/tests/fx/converters/fx_test_utils.py
+++ b/tests/fx/converters/fx_test_utils.py
@@ -40,20 +40,21 @@ class MethodModule(torch.nn.Module):
         return m(*self.args, **self.kwargs)
 
 
-def verify_outputs(mod1, mod2, inp, rtol=3e-3, atol=1e-2, equal_nan=False):
+def verify_outputs(mod, mgx_mod, inp, rtol=3e-3, atol=1e-2, equal_nan=False):
     if not isinstance(inp, (list, tuple)):
         inp = (inp, )
-    out1, out2 = mod1(*inp), mod2(*inp)
+    inp_mgx = [i.cuda() for i in inp]
+    out1, out2 = mod(*inp), mgx_mod(*inp_mgx)
 
     if isinstance(out1, (list, tuple)):
         assert len(out1) == len(out2)
         assert all(
-            torch.allclose(o1, o2, rtol=rtol, atol=atol, equal_nan=equal_nan)
+            torch.allclose(o1.cpu(), o2.cpu(), rtol=rtol, atol=atol, equal_nan=equal_nan)
             for o1, o2 in zip(out1, out2))
 
     else:
-        assert torch.allclose(out1,
-                              out2,
+        assert torch.allclose(out1.cpu(),
+                              out2.cpu(),
                               rtol=rtol,
                               atol=atol,
                               equal_nan=equal_nan)

--- a/tests/fx/converters/test_activations.py
+++ b/tests/fx/converters/test_activations.py
@@ -7,11 +7,11 @@ from fx_test_utils import randbounds, FuncModule, MethodModule, convert_to_mgx, 
                                       (1, 3, 6, 128, 128)])
 def test_clamp(inp_size):
     min_, max_ = randbounds(-1, 1)
-    inp = torch.randn(inp_size).cuda()
+    inp = torch.randn(inp_size)
 
-    mod1 = FuncModule(torch.clamp, max=max_).cuda()
-    mod2 = FuncModule(torch.clamp, min=min_, max=max_).cuda()
-    mod3 = MethodModule('clamp', min=min_, max=max_).cuda()
+    mod1 = FuncModule(torch.clamp, max=max_)
+    mod2 = FuncModule(torch.clamp, min=min_, max=max_)
+    mod3 = MethodModule('clamp', min=min_, max=max_)
 
     for mod in [mod1, mod2, mod3]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -21,8 +21,8 @@ def test_clamp(inp_size):
 @pytest.mark.parametrize('inp_size', [(11, 3, 9), (64, 1000)])
 def test_hardtanh(inp_size):
     min_, max_ = randbounds(-1, 1)
-    inp = torch.randn(inp_size).cuda()
-    mod = torch.nn.Hardtanh(min_, max_).cuda()
+    inp = torch.randn(inp_size)
+    mod = torch.nn.Hardtanh(min_, max_)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
@@ -31,8 +31,8 @@ def test_hardtanh(inp_size):
 @pytest.mark.parametrize('inp_size, dim', [((11, 3, 9), 1),
                                            ((32, 12, 100), -1)])
 def test_softmax(inp_size, dim):
-    inp = torch.randn(inp_size).cuda()
-    mod = torch.nn.Softmax(dim).cuda()
+    inp = torch.randn(inp_size)
+    mod = torch.nn.Softmax(dim)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
@@ -50,16 +50,15 @@ def test_softmax(inp_size, dim):
     torch.nn.Softsign(),
 ])
 def test_noparam_activation_funcs(mod):
-    inp = torch.randn(5, 7, 2, 1, 2).cuda()
-    mod.cuda()
+    inp = torch.randn(5, 7, 2, 1, 2)
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
 
 
 @pytest.mark.parametrize('method', ['relu', 'sigmoid', 'tanh'])
 def test_noparam_activation_methods(method):
-    inp = torch.randn(5, 7, 2, 1, 2).cuda()
-    mod = MethodModule(method).cuda()
+    inp = torch.randn(5, 7, 2, 1, 2)
+    mod = MethodModule(method)
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
 
@@ -70,8 +69,8 @@ def test_noparam_activation_methods(method):
     ((2, ), 0),
 ])
 def test_leaky_relu(inp_size, alpha):
-    inp = torch.randn(inp_size).cuda()
-    mod = torch.nn.LeakyReLU(negative_slope=alpha).cuda()
+    inp = torch.randn(inp_size)
+    mod = torch.nn.LeakyReLU(negative_slope=alpha)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
@@ -83,8 +82,8 @@ def test_leaky_relu(inp_size, alpha):
     ((2, ), 3.2),
 ])
 def test_elu(inp_size, alpha):
-    inp = torch.randn(inp_size).cuda()
-    mod = torch.nn.ELU(alpha=alpha).cuda()
+    inp = torch.randn(inp_size)
+    mod = torch.nn.ELU(alpha=alpha)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_bool_ops.py
+++ b/tests/fx/converters/test_bool_ops.py
@@ -4,32 +4,32 @@ from fx_test_utils import FuncModule, MethodModule, convert_to_mgx, verify_outpu
 
 
 def test_where():
-    inp = torch.randn(32, 43, 11, 2, 1).cuda()
-    other = torch.randn(32, 1, 11, 2, 12).cuda()
+    inp = torch.randn(32, 43, 11, 2, 1)
+    other = torch.randn(32, 1, 11, 2, 12)
     cond = inp >= 0
 
-    mod = FuncModule(torch.where, input=inp, other=other).cuda()
+    mod = FuncModule(torch.where, input=inp, other=other)
 
     mgx_mod = convert_to_mgx(mod, [cond])
     verify_outputs(mod, mgx_mod, cond)
 
 
 def test_maximum():
-    inp = torch.randn(32, 43, 11, 2, 1).cuda()
-    other = torch.randn(32, 1, 11, 2, 12).cuda()
+    inp = torch.randn(32, 43, 11, 2, 1)
+    other = torch.randn(32, 1, 11, 2, 12)
 
-    mod = FuncModule(torch.maximum, other=other).cuda()
+    mod = FuncModule(torch.maximum, other=other)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
 
 
 def test_masked_fill():
-    inp = torch.randn(32, 43, 11, 2, 1).cuda()
-    mask = torch.randn(1, 43, 11, 1, 1).cuda() > 0
+    inp = torch.randn(32, 43, 11, 2, 1)
+    mask = torch.randn(1, 43, 11, 1, 1) > 0
     value = 2
 
-    mod = MethodModule('masked_fill', mask=mask, value=value).cuda()
+    mod = MethodModule('masked_fill', mask=mask, value=value)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_convolution.py
+++ b/tests/fx/converters/test_convolution.py
@@ -7,14 +7,14 @@ from fx_test_utils import convert_to_mgx, verify_outputs
                          [(3, 1, 1, 0), ((3, ), 1, 1, 0), (3, 3, 2, (2, )),
                           (2, 2, 1, 'valid'), (5, 1, 2, 'same')])
 def test_conv1d(kernel_size, stride, dilation, padding):
-    inp = torch.randn(8, 3, 50).cuda()
+    inp = torch.randn(8, 3, 50)
 
     mod = torch.nn.Conv1d(3,
                           16,
                           kernel_size=kernel_size,
                           stride=stride,
                           dilation=dilation,
-                          padding=padding).cuda()
+                          padding=padding)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
@@ -24,14 +24,14 @@ def test_conv1d(kernel_size, stride, dilation, padding):
                          [(3, 1, 1, 0), ((3, 5), 1, 1, 0), (3, 3, 2, (1, 2)),
                           (2, (2, 3), 1, 'valid'), (5, 1, 2, 'same')])
 def test_conv2d(kernel_size, stride, dilation, padding):
-    inp = torch.randn(8, 3, 50, 50).cuda()
+    inp = torch.randn(8, 3, 50, 50)
 
     mod = torch.nn.Conv2d(3,
                           16,
                           kernel_size=kernel_size,
                           stride=stride,
                           dilation=dilation,
-                          padding=padding).cuda()
+                          padding=padding)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
@@ -42,14 +42,14 @@ def test_conv2d(kernel_size, stride, dilation, padding):
                           (3, 3, 2, (3, 1, 2)), (2, (2, 3, 4), 1, 'valid'),
                           (5, 1, 2, 'same')])
 def test_conv3d(kernel_size, stride, dilation, padding):
-    inp = torch.randn(8, 3, 50, 50, 100).cuda()
+    inp = torch.randn(8, 3, 50, 50, 100)
 
     mod = torch.nn.Conv3d(3,
                           16,
                           kernel_size=kernel_size,
                           stride=stride,
                           dilation=dilation,
-                          padding=padding).cuda()
+                          padding=padding)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_embedding.py
+++ b/tests/fx/converters/test_embedding.py
@@ -5,10 +5,10 @@ from fx_test_utils import convert_to_mgx, verify_outputs
 
 @pytest.mark.parametrize("num_embed, embed_dim", [(10, 5), (6, 20), (100, 64)])
 def test_embedding(num_embed, embed_dim):
-    inp = torch.tensor([[0, 5, 2], [1, 1, 3]]).cuda()
+    inp = torch.tensor([[0, 5, 2], [1, 1, 3]])
 
     mod = torch.nn.Embedding(num_embeddings=num_embed,
-                             embedding_dim=embed_dim).cuda()
+                             embedding_dim=embed_dim)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_getitem.py
+++ b/tests/fx/converters/test_getitem.py
@@ -21,8 +21,8 @@ from fx_test_utils import LambdaModule, convert_to_mgx, verify_outputs
                 torch.tensor([1, 0])],
 ])
 def test_getitem(slice_func):
-    inp = torch.randn(32, 43, 11, 2, 12).cuda()
-    mod = LambdaModule(slice_func).cuda()
+    inp = torch.randn(32, 43, 11, 2, 12)
+    mod = LambdaModule(slice_func)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_identity.py
+++ b/tests/fx/converters/test_identity.py
@@ -5,15 +5,14 @@ from fx_test_utils import MethodModule, convert_to_mgx, verify_outputs
 
 @pytest.mark.parametrize('mod', [torch.nn.Dropout()])
 def test_identity_mods(mod):
-    inp = torch.randn(5, 7, 4, 2).cuda()
-    mod.cuda()
+    inp = torch.randn(5, 7, 4, 2)
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
 
 
 @pytest.mark.parametrize('method', ['detach'])
 def test_identity_methods(method):
-    inp = torch.randn(5, 7, 4, 2).cuda()
-    mod = MethodModule(method).cuda()
+    inp = torch.randn(5, 7, 4, 2)
+    mod = MethodModule(method)
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_linear.py
+++ b/tests/fx/converters/test_linear.py
@@ -17,8 +17,8 @@ class AddMMModule(FuncModule):
 
 @pytest.mark.parametrize('inp_size', [(32, 64), (8, 3, 50), (2, 3, 3, 24)])
 def test_linear(inp_size):
-    mod = torch.nn.Linear(inp_size[-1], 100).cuda()
-    inp = torch.randn(inp_size).cuda()
+    mod = torch.nn.Linear(inp_size[-1], 100)
+    inp = torch.randn(inp_size)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
@@ -28,9 +28,9 @@ def test_linear(inp_size):
                          [((32, 64), (64, 15)), ((8, 3, 50), (1, 50, 2)),
                           ((12, 1, 24, 48), (20, 48, 4))])
 def test_matmul(in_shape, other_shape):
-    inp = torch.randn(in_shape).cuda()
-    other = torch.randn(other_shape).cuda()
-    mod = MatmulModule(torch.matmul).cuda()
+    inp = torch.randn(in_shape)
+    other = torch.randn(other_shape)
+    mod = MatmulModule(torch.matmul)
 
     mgx_mod = convert_to_mgx(mod, [inp, other])
     verify_outputs(mod, mgx_mod, (inp, other))
@@ -41,10 +41,10 @@ def test_matmul(in_shape, other_shape):
     ((3, 1), (3, 50), (50, 2), 1.5, 2.3),
 ])
 def test_addmm(in_shape, m1_shape, m2_shape, beta, alpha):
-    inp = torch.randn(in_shape).cuda()
-    m1 = torch.randn(m1_shape).cuda()
-    m2 = torch.randn(m2_shape).cuda()
-    mod = AddMMModule(torch.addmm, beta=beta, alpha=alpha).cuda()
+    inp = torch.randn(in_shape)
+    m1 = torch.randn(m1_shape)
+    m2 = torch.randn(m2_shape)
+    mod = AddMMModule(torch.addmm, beta=beta, alpha=alpha)
 
     mgx_mod = convert_to_mgx(mod, [inp, m1, m2])
     verify_outputs(mod, mgx_mod, (inp, m1, m2))

--- a/tests/fx/converters/test_literals.py
+++ b/tests/fx/converters/test_literals.py
@@ -5,7 +5,7 @@ from fx_test_utils import MethodModule, convert_to_mgx, verify_outputs
 
 @pytest.mark.parametrize('size', [(2, 4, 1), (1, ), (2, 6, 7, 5, 4)])
 def test_noparam_activation_methods(size):
-    inp = torch.randn(2, 5, 4, 3).cuda()
-    mod = MethodModule('new_zeros', size=size).cuda()
+    inp = torch.randn(2, 5, 4, 3)
+    mod = MethodModule('new_zeros', size=size)
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_maxmin.py
+++ b/tests/fx/converters/test_maxmin.py
@@ -17,8 +17,8 @@ class TopKModule(torch.nn.Module):
         vals, inds = func_out[0], func_out[1]
         size = [s for s in self.size]
         size[self.dim] = self.k
-        vals = vals + torch.ones(size, dtype=torch.float32).cuda()
-        inds = inds + torch.ones(size, dtype=torch.long).cuda()
+        vals = vals + torch.ones(size, dtype=torch.float32)
+        inds = inds + torch.ones(size, dtype=torch.long)
         return [vals, inds]
 
 
@@ -28,8 +28,8 @@ class TopKModule(torch.nn.Module):
     (5, 2, False),
 ])
 def test_topk(k, dim, largest):
-    inp = torch.randn(10, 2, 12, 8, 14).cuda()
-    mod = TopKModule(size=inp.size(), k=k, dim=dim, largest=largest).cuda()
+    inp = torch.randn(10, 2, 12, 8, 14)
+    mod = TopKModule(size=inp.size(), k=k, dim=dim, largest=largest)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
@@ -41,10 +41,10 @@ def test_topk(k, dim, largest):
     (None, False),
 ])
 def test_argmax(dim, keepdim):
-    inp = torch.randn(10, 2, 12, 8, 14).cuda()
+    inp = torch.randn(10, 2, 12, 8, 14)
 
-    mod_func = FuncModule(torch.argmax, dim=dim, keepdim=keepdim).cuda()
-    mod_method = MethodModule('argmax', dim=dim, keepdim=keepdim).cuda()
+    mod_func = FuncModule(torch.argmax, dim=dim, keepdim=keepdim)
+    mod_method = MethodModule('argmax', dim=dim, keepdim=keepdim)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])

--- a/tests/fx/converters/test_norm_ops.py
+++ b/tests/fx/converters/test_norm_ops.py
@@ -7,11 +7,11 @@ from fx_test_utils import convert_to_mgx, verify_outputs
                                                      (25, 1e-2, 0.4),
                                                      (2, 1e-10, 0.7)])
 def test_batchnorm2d(num_feat, eps, momentum):
-    inp = torch.randn(8, num_feat, 50, 50).cuda()
+    inp = torch.randn(8, num_feat, 50, 50)
 
     mod = torch.nn.BatchNorm2d(num_features=num_feat,
                                eps=eps,
-                               momentum=momentum).cuda().eval()
+                               momentum=momentum).eval()
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
@@ -21,10 +21,10 @@ def test_batchnorm2d(num_feat, eps, momentum):
                                                    ((50, 50), 1e-2),
                                                    ((6, 50, 50), 1e-10)])
 def test_layernorm(normalized_shape, eps):
-    inp = torch.randn(8, 6, 50, 50).cuda()
+    inp = torch.randn(8, 6, 50, 50)
 
     mod = torch.nn.LayerNorm(normalized_shape=normalized_shape,
-                             eps=eps).cuda().eval()
+                             eps=eps).eval()
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
@@ -34,11 +34,11 @@ def test_layernorm(normalized_shape, eps):
                                                            (4, 4, 1e-2),
                                                            (1, 3, 1e-10)])
 def test_groupnorm(num_groups, num_channels, eps):
-    inp = torch.randn(8, num_channels, 50, 50).cuda()
+    inp = torch.randn(8, num_channels, 50, 50)
 
     mod = torch.nn.GroupNorm(num_groups=num_groups,
                              num_channels=num_channels,
-                             eps=eps).cuda().eval()
+                             eps=eps).eval()
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_pad.py
+++ b/tests/fx/converters/test_pad.py
@@ -10,9 +10,9 @@ from fx_test_utils import FuncModule, convert_to_mgx, verify_outputs
     ((1, 3, 1, 2, 2, 1, 2, 3, 3, 1), -0.1),
 ])
 def test_pad(pads, value):
-    inp = torch.randn(32, 43, 11, 2, 12).cuda()
+    inp = torch.randn(32, 43, 11, 2, 12)
 
-    mod = FuncModule(torch.nn.functional.pad, pad=pads, value=value).cuda()
+    mod = FuncModule(torch.nn.functional.pad, pad=pads, value=value)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_pointwise_ops.py
+++ b/tests/fx/converters/test_pointwise_ops.py
@@ -23,12 +23,12 @@ from fx_test_utils import FuncModule, MethodModule, convert_to_mgx, verify_outpu
         marks=pytest.mark.skip(reason="trunc_div converter not implemented")),
 ])
 def test_pointwise_func(oper):
-    inps1 = [torch.randn(4, 7, 3).cuda(), torch.randn(4, 7, 3).cuda()]
-    inps2 = [torch.randn(4, 7, 3).cuda(), 2]
-    inps3 = [torch.randn(4, 7, 3).cuda(), torch.randn(1, 1, 3).cuda()]
+    inps1 = [torch.randn(4, 7, 3), torch.randn(4, 7, 3)]
+    inps2 = [torch.randn(4, 7, 3), 2]
+    inps3 = [torch.randn(4, 7, 3), torch.randn(1, 1, 3)]
 
     for inps in [inps1, inps2, inps3]:
-        mod = FuncModule(oper, inps[1]).cuda()
+        mod = FuncModule(oper, inps[1])
         mgx_mod = convert_to_mgx(mod, [inps[0]])
         verify_outputs(mod, mgx_mod, inps[0], equal_nan=True)
 
@@ -42,12 +42,12 @@ def test_pointwise_func(oper):
     'pow',
 ])
 def test_pointwise_method(method):
-    inps1 = [torch.randn(4, 7, 3).cuda(), torch.randn(4, 7, 3).cuda()]
-    inps2 = [torch.randn(4, 7, 3).cuda(), 2]
-    inps3 = [torch.randn(4, 7, 3).cuda(), torch.randn(1, 1, 3).cuda()]
+    inps1 = [torch.randn(4, 7, 3), torch.randn(4, 7, 3)]
+    inps2 = [torch.randn(4, 7, 3), 2]
+    inps3 = [torch.randn(4, 7, 3), torch.randn(1, 1, 3)]
 
     for inps in [inps1, inps2, inps3]:
-        mod = MethodModule(method, inps[-1]).cuda()
+        mod = MethodModule(method, inps[-1])
         mgx_mod = convert_to_mgx(mod, [inps[0]])
         verify_outputs(mod, mgx_mod, inps[0], equal_nan=True)
 
@@ -64,17 +64,17 @@ def test_pointwise_method(method):
     torch.ceil,
 ])
 def test_unary_func(oper):
-    inp = torch.randn(2, 9, 11, 1).cuda()
+    inp = torch.randn(2, 9, 11, 1)
 
-    mod = FuncModule(oper).cuda()
+    mod = FuncModule(oper)
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp, equal_nan=True)
 
 
 @pytest.mark.parametrize('oper', [torch.log, torch.log1p])
 def test_log(oper):
-    inp = torch.abs(torch.randn(2, 9, 11, 1)).cuda()
-    mod = FuncModule(oper).cuda()
+    inp = torch.abs(torch.randn(2, 9, 11, 1))
+    mod = FuncModule(oper)
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
 
@@ -91,8 +91,8 @@ def test_log(oper):
     torch.atan,
 ])
 def test_trig_func(oper):
-    inp = torch.randn(2, 9, 11, 1).cuda()
+    inp = torch.randn(2, 9, 11, 1)
 
-    mod = FuncModule(oper).cuda()
+    mod = FuncModule(oper)
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp, equal_nan=True)

--- a/tests/fx/converters/test_pooling.py
+++ b/tests/fx/converters/test_pooling.py
@@ -8,7 +8,7 @@ from fx_test_utils import convert_to_mgx, verify_outputs
     [(2, 1, 0, 1, True), ((2, 4), 1, 0, 1, False), (5, 5, (1, 2), 1, True),
      pytest.param(2, 1, 0, 2, True, marks=pytest.mark.xfail)])
 def test_maxpool2d(kernel_size, stride, padding, dilation, ceil_mode):
-    inp = torch.randn(8, 3, 50, 50).cuda()
+    inp = torch.randn(8, 3, 50, 50)
     mod = torch.nn.MaxPool2d(kernel_size=kernel_size,
                              stride=stride,
                              padding=padding,
@@ -24,7 +24,7 @@ def test_maxpool2d(kernel_size, stride, padding, dilation, ceil_mode):
     [(2, 1, 0, True, False), ((2, 4), 1, 0, False, True),
      (5, 5, (1, 2), True, True), (2, 1, 0, False, False)])
 def test_avgpool2d(kernel_size, stride, padding, ceil_mode, count_include_pad):
-    inp = torch.randn(8, 3, 50, 50).cuda()
+    inp = torch.randn(8, 3, 50, 50)
     mod = torch.nn.AvgPool2d(kernel_size=kernel_size,
                              stride=stride,
                              padding=padding,
@@ -39,7 +39,7 @@ def test_avgpool2d(kernel_size, stride, padding, ceil_mode, count_include_pad):
                                        pytest.param(
                                            (40, 40), marks=pytest.mark.xfail)])
 def test_adaptive_avgpool2d(out_shape):
-    inp = torch.randn(8, 3, 50, 50).cuda()
-    mod = torch.nn.AdaptiveAvgPool2d(out_shape).cuda()
+    inp = torch.randn(8, 3, 50, 50)
+    mod = torch.nn.AdaptiveAvgPool2d(out_shape)
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_reduce_ops.py
+++ b/tests/fx/converters/test_reduce_ops.py
@@ -6,9 +6,9 @@ from fx_test_utils import FuncModule, MethodModule, convert_to_mgx, verify_outpu
 @pytest.mark.parametrize('dim, keepdim', [(0, True), (-1, False), (3, False),
                                           ([-1, -2], True)])
 def test_mean(dim, keepdim):
-    inp = torch.randn(32, 43, 11, 2, 12).cuda()
-    mod_func = FuncModule(torch.mean, dim=dim, keepdim=keepdim).cuda()
-    mod_method = MethodModule('mean', dim=dim, keepdim=keepdim).cuda()
+    inp = torch.randn(32, 43, 11, 2, 12)
+    mod_func = FuncModule(torch.mean, dim=dim, keepdim=keepdim)
+    mod_method = MethodModule('mean', dim=dim, keepdim=keepdim)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -18,13 +18,13 @@ def test_mean(dim, keepdim):
 @pytest.mark.parametrize('dim, keepdim', [(0, True), (-1, False),
                                           ([2, 3], False), (None, None)])
 def test_sum(dim, keepdim):
-    inp = torch.randn(32, 43, 11, 2, 12).cuda()
+    inp = torch.randn(32, 43, 11, 2, 12)
     if dim is not None:
-        mod_func = FuncModule(torch.sum, dim=dim, keepdim=keepdim).cuda()
-        mod_method = MethodModule('sum', dim=dim, keepdim=keepdim).cuda()
+        mod_func = FuncModule(torch.sum, dim=dim, keepdim=keepdim)
+        mod_method = MethodModule('sum', dim=dim, keepdim=keepdim)
     else:
-        mod_func = FuncModule(torch.sum).cuda()
-        mod_method = MethodModule('sum').cuda()
+        mod_func = FuncModule(torch.sum)
+        mod_method = MethodModule('sum')
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -34,13 +34,13 @@ def test_sum(dim, keepdim):
 @pytest.mark.parametrize('dim, keepdim', [(0, True), (-1, False), (3, False),
                                           (None, None)])
 def test_prod(dim, keepdim):
-    inp = torch.randn(32, 43, 11, 2, 12).cuda()
+    inp = torch.randn(32, 43, 11, 2, 12)
     if dim is not None:
-        mod_func = FuncModule(torch.prod, dim=dim, keepdim=keepdim).cuda()
-        mod_method = MethodModule('prod', dim=dim, keepdim=keepdim).cuda()
+        mod_func = FuncModule(torch.prod, dim=dim, keepdim=keepdim)
+        mod_method = MethodModule('prod', dim=dim, keepdim=keepdim)
     else:
-        mod_func = FuncModule(torch.prod).cuda()
-        mod_method = MethodModule('prod').cuda()
+        mod_func = FuncModule(torch.prod)
+        mod_method = MethodModule('prod')
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -49,9 +49,9 @@ def test_prod(dim, keepdim):
 
 @pytest.mark.parametrize('dim', [0, -1, 3])
 def test_cumsum(dim):
-    inp = torch.randn(32, 43, 11, 2, 12).cuda()
-    mod_func = FuncModule(torch.cumsum, dim=dim).cuda()
-    mod_method = MethodModule('cumsum', dim=dim).cuda()
+    inp = torch.randn(32, 43, 11, 2, 12)
+    mod_func = FuncModule(torch.cumsum, dim=dim)
+    mod_method = MethodModule('cumsum', dim=dim)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])

--- a/tests/fx/converters/test_rnn.py
+++ b/tests/fx/converters/test_rnn.py
@@ -23,11 +23,11 @@ class RNNModule(torch.nn.Module):
     ])
 def test_lstm(input_size, hidden_size, num_layers, batch_first, bidirectional):
     batch_size = 1
-    inp = torch.randn(4, batch_size, input_size).cuda()
+    inp = torch.randn(4, batch_size, input_size)
     inp = inp.transpose(0, 1) if batch_first else inp
     num_dir = 2 if bidirectional else 1
-    h0 = torch.randn(num_dir * num_layers, batch_size, hidden_size).cuda()
-    c0 = torch.randn(num_dir * num_layers, batch_size, hidden_size).cuda()
+    h0 = torch.randn(num_dir * num_layers, batch_size, hidden_size)
+    c0 = torch.randn(num_dir * num_layers, batch_size, hidden_size)
 
     mod = RNNModule(
         torch.nn.LSTM(
@@ -36,7 +36,7 @@ def test_lstm(input_size, hidden_size, num_layers, batch_first, bidirectional):
             num_layers=num_layers,
             batch_first=batch_first,
             bidirectional=bidirectional,
-        )).cuda()
+        ))
     mod.eval()
 
     mgx_mod = convert_to_mgx(mod, [inp, h0, c0])

--- a/tests/fx/converters/test_scatter_ops.py
+++ b/tests/fx/converters/test_scatter_ops.py
@@ -11,15 +11,15 @@ from fx_test_utils import FuncModule, MethodModule, convert_to_mgx, verify_outpu
     ([4, 8, 11, 2, 12], -3, [4, 8, 2, 2, 12], slice(8, -1, 1)),
 ])
 def test_slice_scatter(in_size, dim, src_dims, slc):
-    inp = torch.zeros(*in_size).cuda()
-    src = torch.randn(*src_dims).cuda()
+    inp = torch.zeros(*in_size)
+    src = torch.randn(*src_dims)
 
     mod = FuncModule(torch.slice_scatter,
                      src=src,
                      dim=dim,
                      start=slc.start,
                      end=slc.stop,
-                     step=slc.step).cuda()
+                     step=slc.step)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
@@ -32,10 +32,10 @@ def test_slice_scatter(in_size, dim, src_dims, slc):
     ([4, 8, 11, 2, 12], -2, [4, 8, 11, 12], 0),
 ])
 def test_select_scatter(in_size, dim, src_dims, idx):
-    inp = torch.zeros(*in_size).cuda()
-    src = torch.randn(*src_dims).cuda()
+    inp = torch.zeros(*in_size)
+    src = torch.randn(*src_dims)
 
-    mod = FuncModule(torch.select_scatter, src=src, dim=dim, index=idx).cuda()
+    mod = FuncModule(torch.select_scatter, src=src, dim=dim, index=idx)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_shape_ops.py
+++ b/tests/fx/converters/test_shape_ops.py
@@ -18,9 +18,9 @@ class StackModule(FuncModule):
 
 @pytest.mark.parametrize('start,end', [(0, -1), (0, 2), (4, -1), (3, 5)])
 def test_flatten(start, end):
-    inp = torch.randn(8, 7, 2, 3, 12, 34, 1, 2).cuda()
-    mod_func = FuncModule(torch.flatten, start_dim=start, end_dim=end).cuda()
-    mod_method = MethodModule('flatten', start_dim=start, end_dim=end).cuda()
+    inp = torch.randn(8, 7, 2, 3, 12, 34, 1, 2)
+    mod_func = FuncModule(torch.flatten, start_dim=start, end_dim=end)
+    mod_method = MethodModule('flatten', start_dim=start, end_dim=end)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -30,9 +30,9 @@ def test_flatten(start, end):
 @pytest.mark.parametrize('in_shape,out_shape', [((50, 25), (5, 10, 25)),
                                                 ((1, 6, 21, 4), (1, 126, 4))])
 def test_reshape(in_shape, out_shape):
-    inp = torch.randn(in_shape).cuda()
-    mod_func = FuncModule(torch.reshape, shape=out_shape).cuda()
-    mod_method = MethodModule('reshape', out_shape).cuda()
+    inp = torch.randn(in_shape)
+    mod_func = FuncModule(torch.reshape, shape=out_shape)
+    mod_method = MethodModule('reshape', out_shape)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -42,9 +42,9 @@ def test_reshape(in_shape, out_shape):
 @pytest.mark.parametrize('perm', [(1, 2, 3, 0), (0, 2, 3, 1), (3, 2, 1, 0),
                                   (1, 0, -2, -1)])
 def test_permute(perm):
-    inp = torch.randn(6, 2, 5, 4).cuda()
-    mod_func = FuncModule(torch.permute, dims=perm).cuda()
-    mod_method = MethodModule('permute', *perm).cuda()
+    inp = torch.randn(6, 2, 5, 4)
+    mod_func = FuncModule(torch.permute, dims=perm)
+    mod_method = MethodModule('permute', *perm)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -53,9 +53,9 @@ def test_permute(perm):
 
 @pytest.mark.parametrize('dim0, dim1', [(1, 2), (0, 3), (2, 0)])
 def test_transpose(dim0, dim1):
-    inp = torch.randn(6, 2, 5, 4).cuda()
-    mod_func = FuncModule(torch.transpose, dim0=dim0, dim1=dim1).cuda()
-    mod_method = MethodModule('transpose', dim0=dim0, dim1=dim1).cuda()
+    inp = torch.randn(6, 2, 5, 4)
+    mod_func = FuncModule(torch.transpose, dim0=dim0, dim1=dim1)
+    mod_method = MethodModule('transpose', dim0=dim0, dim1=dim1)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -65,17 +65,17 @@ def test_transpose(dim0, dim1):
 @pytest.mark.parametrize('mem_shape, view_shape', [((6, 2, 5, 4), (6, 10, 4)),
                                                    ((6, 3, 4), (3, 24))])
 def test_contiguous(mem_shape, view_shape):
-    inp = torch.randn(mem_shape).view(view_shape).cuda()
-    mod = MethodModule('contiguous').cuda()
+    inp = torch.randn(mem_shape).view(view_shape)
+    mod = MethodModule('contiguous')
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
 
 
 @pytest.mark.parametrize('chunks, dim', [(5, 1), (10, 3)])
 def test_chunk(chunks, dim):
-    inp = torch.randn(20, 12, 15, 40).cuda()
-    mod_func = FuncModule(torch.chunk, chunks=chunks, dim=dim).cuda()
-    mod_method = MethodModule('chunk', chunks=chunks, dim=dim).cuda()
+    inp = torch.randn(20, 12, 15, 40)
+    mod_func = FuncModule(torch.chunk, chunks=chunks, dim=dim)
+    mod_method = MethodModule('chunk', chunks=chunks, dim=dim)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -84,9 +84,9 @@ def test_chunk(chunks, dim):
 
 @pytest.mark.parametrize('dim', [0, 3, -1])
 def test_stack(dim):
-    inps = [torch.randn(20, 12, 15, 40).cuda() for _ in range(3)]
+    inps = [torch.randn(20, 12, 15, 40) for _ in range(3)]
 
-    mod = StackModule(torch.stack, dim=dim).cuda()
+    mod = StackModule(torch.stack, dim=dim)
 
     mgx_mod = convert_to_mgx(mod, inps)
     verify_outputs(mod, mgx_mod, inps)
@@ -94,9 +94,9 @@ def test_stack(dim):
 
 @pytest.mark.parametrize('split_size, dim', [(5, 1), (7, 2)])
 def test_split(split_size, dim):
-    inp = torch.randn(20, 12, 15, 40).cuda()
-    mod_func = FuncModule(torch.split, split_size, dim=dim).cuda()
-    mod_method = MethodModule('split', split_size, dim=dim).cuda()
+    inp = torch.randn(20, 12, 15, 40)
+    mod_func = FuncModule(torch.split, split_size, dim=dim)
+    mod_method = MethodModule('split', split_size, dim=dim)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -106,8 +106,8 @@ def test_split(split_size, dim):
 @pytest.mark.parametrize('s1,s2,dim', [((6, 5, 7), (2, 5, 7), 0),
                                        ((4, 5, 1, 9), (4, 5, 11, 9), 2)])
 def test_cat(s1, s2, dim):
-    t1, t2 = torch.randn(s1).cuda(), torch.randn(s2).cuda()
-    mod = CatModule(torch.cat, dim=dim).cuda()
+    t1, t2 = torch.randn(s1), torch.randn(s2)
+    mod = CatModule(torch.cat, dim=dim)
 
     mgx_mod = convert_to_mgx(mod, [t1, t2])
     verify_outputs(mod, mgx_mod, (t1, t2))
@@ -115,10 +115,10 @@ def test_cat(s1, s2, dim):
 
 @pytest.mark.parametrize('dim', [1, -2, None])
 def test_squeeze(dim):
-    inp = torch.randn(24, 1, 1, 8).cuda()
+    inp = torch.randn(24, 1, 1, 8)
     kwargs = {'dim': dim} if dim is not None else {}
-    mod_func = FuncModule(torch.squeeze, **kwargs).cuda()
-    mod_method = MethodModule('squeeze', **kwargs).cuda()
+    mod_func = FuncModule(torch.squeeze, **kwargs)
+    mod_method = MethodModule('squeeze', **kwargs)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -127,9 +127,9 @@ def test_squeeze(dim):
 
 @pytest.mark.parametrize('dim', [0, -1, 2])
 def test_unsqueeze(dim):
-    inp = torch.randn(24, 2, 4).cuda()
-    mod_func = FuncModule(torch.unsqueeze, dim=dim).cuda()
-    mod_method = MethodModule('unsqueeze', dim=dim).cuda()
+    inp = torch.randn(24, 2, 4)
+    mod_func = FuncModule(torch.unsqueeze, dim=dim)
+    mod_method = MethodModule('unsqueeze', dim=dim)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -143,8 +143,8 @@ def test_unsqueeze(dim):
 @pytest.mark.parametrize('out_shape', [(2, 4, 4), (1, 2, 3, 4),
                                        (2, 3, 2, 2, 4)])
 def test_expand(out_shape):
-    inp = torch.randn(2, 1, 4).cuda()
-    mod = MethodModule('expand', *out_shape).cuda()
+    inp = torch.randn(2, 1, 4)
+    mod = MethodModule('expand', *out_shape)
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
 
@@ -155,9 +155,9 @@ def test_expand(out_shape):
     ((24, 3, 1, 8), (2, 6, 5, 3)),
 ])
 def test_tile(size, dims):
-    inp = torch.randn(size).cuda()
-    mod_func = FuncModule(torch.tile, dims=dims).cuda()
-    mod_method = MethodModule('tile', dims=dims).cuda()
+    inp = torch.randn(size)
+    mod_func = FuncModule(torch.tile, dims=dims)
+    mod_method = MethodModule('tile', dims=dims)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])
@@ -170,8 +170,8 @@ def test_tile(size, dims):
     (2, 0, 7),
 ])
 def test_narrow(dim, start, length):
-    inp = torch.randn(10, 15, 12, 8).cuda()
-    mod = FuncModule(torch.narrow, dim=dim, start=start, length=length).cuda()
+    inp = torch.randn(10, 15, 12, 8)
+    mod = FuncModule(torch.narrow, dim=dim, start=start, length=length)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
@@ -183,8 +183,8 @@ def test_narrow(dim, start, length):
     ((24, 3, 1, 8), -1),
 ])
 def test_unbind(size, dim):
-    inp = torch.randn(size).cuda()
-    mod = FuncModule(torch.unbind, dim=dim).cuda()
+    inp = torch.randn(size)
+    mod = FuncModule(torch.unbind, dim=dim)
 
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
@@ -196,16 +196,16 @@ def test_unbind(size, dim):
     ((4, 1, 2, 2), (4, 2, 2, 2), (2, 3, 3, 1), 2),
 ])
 def test_as_strided(size, new_size, strides, offset):
-    inp = torch.randn(size).cuda()
+    inp = torch.randn(size)
 
     mod_func = FuncModule(torch.as_strided,
                           size=new_size,
                           stride=strides,
-                          storage_offset=offset).cuda()
+                          storage_offset=offset)
     mod_method = MethodModule('as_strided',
                               size=new_size,
                               stride=strides,
-                              storage_offset=offset).cuda()
+                              storage_offset=offset)
 
     for mod in [mod_func, mod_method]:
         mgx_mod = convert_to_mgx(mod, [inp])

--- a/tests/fx/converters/test_torchvision_ops.py
+++ b/tests/fx/converters/test_torchvision_ops.py
@@ -11,10 +11,10 @@ except ImportError:
 @pytest.mark.skipif('torchvision' not in sys.modules,
                     reason="requires the torchvision library")
 def test_stochastic_depth():
-    inp = torch.randn(5, 7, 4, 2).cuda()
+    inp = torch.randn(5, 7, 4, 2)
     mod = FuncModule(torchvision.ops.stochastic_depth,
                      p=0.5,
                      mode='batch',
-                     training=False).cuda().eval()
+                     training=False).eval()
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/models/test_lowering.py
+++ b/tests/fx/models/test_lowering.py
@@ -24,15 +24,15 @@ DEFAULT_RTOL, DEFAULT_ATOL = 3e-3, 1e-2
         (models.inception_v3(), 1e-1, 1e-1),
     ])
 def test_vision_model(model, rtol, atol):
-    model = model.cuda()
-    sample_inputs = [torch.randn(4, 3, 244, 244).cuda()]
-
-    mgx_model = lower_to_mgx(model, sample_inputs, verbose_log=True)
-
-    mgx_out = mgx_model(*sample_inputs)
+    model = model.eval()
+    sample_inputs = [torch.randn(4, 3, 244, 244)]
     torch_out = model(*sample_inputs)
 
-    assert torch.allclose(mgx_out, torch_out, rtol=rtol, atol=atol)
+    mgx_model = lower_to_mgx(model, sample_inputs, verbose_log=True)
+    mgx_inputs = [i.cuda() for i in sample_inputs]
+    mgx_out = mgx_model(*mgx_inputs)
+    
+    assert torch.allclose(mgx_out.cpu(), torch_out, rtol=rtol, atol=atol)
 
     del mgx_model
     del model


### PR DESCRIPTION
Leave torch model on cpu during lowering process. Two benefits:
1. Torch model no longer needs to occupy device memory, device memory will only be used when migraphx program is compiled.
2. Quantized (Int8) models cannot be executed on device at this time which was causing the lowering process to be incompatible with quantized models.