### PR TITLE
install required rocm-cmake for migraphx

### DIFF
--- a/tools/install_migraphx.sh
+++ b/tools/install_migraphx.sh
@@ -2,6 +2,16 @@ MIGRAPHX_BRANCH=master
 MIGRAPHX_REPO=https://github.com/ROCmSoftwarePlatform/AMDMIGraphX.git
 GPU_ARCH=${1:-"gfx900;gfx906;gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx1102;gfx940"}
 
+# Update rocm-cmake to required version for migraphx
+git clone https://github.com/RadeonOpenCompute/rocm-cmake.git  
+cd rocm-cmake 
+git checkout 5a34e72d9f113eb5d028e740c2def1f944619595 
+mkdir build 
+cd build
+cmake .. 
+cmake --build . --target install
+cd ../..
+
 git clone --single-branch --branch $MIGRAPHX_BRANCH --recursive $MIGRAPHX_REPO
 cd AMDMIGraphX
 


### PR DESCRIPTION
MIGraphX build expects specific rocm-cmake version after test package update.