### PR TITLE
fix import errors and warnings

### DIFF
--- a/py/torch_migraphx/__init__.py
+++ b/py/torch_migraphx/__init__.py
@@ -1,4 +1,5 @@
 from packaging import version
+import migraphx
 from torch import __version__ as _torch_version
 from torch_migraphx import fx, _C
 

--- a/py/torch_migraphx/fx/tracer/acc_tracer/acc_tracer.py
+++ b/py/torch_migraphx/fx/tracer/acc_tracer/acc_tracer.py
@@ -409,7 +409,7 @@ def _rewrite(
             # into RewrittenModule.
             for method_name in dir(base_class):
                 method = getattr(base_class, method_name, None)
-                if method is None and method_name not in {"__doc__"}:
+                if method is None and method_name not in {"__doc__", "_compiled_call_impl"}:
                     _LOGGER.warning(
                         f"{__qualname__} does not have attribute {method_name}"
                     )

--- a/tests/dynamo/converters/dynamo_test_utils.py
+++ b/tests/dynamo/converters/dynamo_test_utils.py
@@ -1,6 +1,5 @@
 from typing import Sequence
 import torch
-# import torch_migraphx.fx.tracer.acc_tracer.acc_tracer as acc_tracer
 import torch_migraphx.fx.tracer.aten_tracer.aten_tracer as aten_tracer
 import torch_migraphx.fx.tracer.acc_tracer.acc_tracer as acc_tracer
 from torch_migraphx.fx.fx2mgx import MGXInterpreter

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = -ra --disable-warnings -v
+addopts = -ra --disable-warnings -v -p torch_migraphx


### PR DESCRIPTION
Since new updates to MIGraphX and PyTorch, importing torch before migraphx results in:
```
free(): invalid pointer
Aborted (core dumped)
```

Pushing temp workaround to import migraphx before torch when importing this library.

Similar issue noted with different packages here:
https://github.com/pytorch/pytorch/issues/19739