### PR TITLE
Link correct .so to not rely on TORCH_USE_RTLD_GLOBAL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,4 @@ COPY ./tools/install_migraphx.sh /
 RUN /install_migraphx.sh ${GPU_ARCH} && rm /install_migraphx.sh
 
 ENV PYTHONPATH=/opt/rocm/lib
-ENV TORCH_USE_RTLD_GLOBAL=YES
 ENV LD_LIBRARY_PATH=/opt/rocm/lib

--- a/py/CMakeLists.txt
+++ b/py/CMakeLists.txt
@@ -11,15 +11,17 @@ find_package(hipsparse REQUIRED)
 find_package(migraphx REQUIRED)
 
 SET(SOURCE_DIR "torch_migraphx/csrc")
-
 include_directories(${SOURCE_DIR})
 SET(SOURCES "${SOURCE_DIR}/mgx_util.cpp")
 
 find_package(pybind11 REQUIRED)
 find_package(Torch REQUIRED)
+find_library(TORCH_PYTHON_LIBRARY torch_python PATHS "${TORCH_INSTALL_PREFIX}/lib")
+message(STATUS "TORCH_PYTHON_LIBRARY: ${TORCH_PYTHON_LIBRARY}")
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 pybind11_add_module(_torch_migraphx ${SOURCES} "${SOURCE_DIR}/torch_migraphx_py.cpp")
 
-target_link_libraries(_torch_migraphx PUBLIC migraphx::c "${TORCH_LIBRARIES}")
+target_link_libraries(_torch_migraphx PUBLIC migraphx::c "${TORCH_LIBRARIES}" ${TORCH_PYTHON_LIBRARY})
 
 set_property(TARGET _torch_migraphx PROPERTY CXX_STANDARD 17)


### PR DESCRIPTION
Relevant PyTorch issue:
https://github.com/pytorch/pytorch/issues/38122