### PR TITLE
Add capability to promote input dtypes

### DIFF
--- a/examples/dynamo/stable_diffusion/stable_diffusion.py
+++ b/examples/dynamo/stable_diffusion/stable_diffusion.py
@@ -44,7 +44,7 @@ def run(args):
                                                    torch_dtype=dtype)
     pipe = pipe.to("cuda")
 
-    # pipe.text_encoder = torch.compile(pipe.text_encoder, backend='migraphx')
+    pipe.text_encoder = torch.compile(pipe.text_encoder, backend='migraphx')
     pipe.unet = torch.compile(pipe.unet, backend='migraphx')
     pipe.vae.decoder = torch.compile(pipe.vae.decoder, backend='migraphx')
 

--- a/py/torch_migraphx/dynamo/passes/remove_ops.py
+++ b/py/torch_migraphx/dynamo/passes/remove_ops.py
@@ -61,6 +61,7 @@ def remove_view_ops(gm: torch.fx.GraphModule):
                     args=og_node.args,
                     kwargs=og_node.kwargs,
                 )
+                new_node.meta = og_node.meta
                 og_node.replace_all_uses_with(new_node)
                 gm.graph.erase_node(og_node)
     gm.graph.eliminate_dead_code()
@@ -90,6 +91,7 @@ def remove_const_ops(gm: torch.fx.GraphModule, device: str = "cuda"):
                         "get_attr",
                         const_name,
                     )
+                    new_node.meta = og_node.meta
                     og_node.replace_all_uses_with(new_node)
                     gm.graph.erase_node(og_node)
 
@@ -118,6 +120,7 @@ def remove_const_ops(gm: torch.fx.GraphModule, device: str = "cuda"):
                         "get_attr",
                         const_name,
                     )
+                    new_node.meta = og_node.meta
                     og_node.replace_all_uses_with(new_node)
                     gm.graph.erase_node(og_node)
 
@@ -142,6 +145,7 @@ def remove_const_ops(gm: torch.fx.GraphModule, device: str = "cuda"):
                         "get_attr",
                         const_name,
                     )
+                    new_node.meta = og_node.meta
                     og_node.replace_all_uses_with(new_node)
                     gm.graph.erase_node(og_node)
 


### PR DESCRIPTION
Dynamo lowering workflow allows mixed input types for some ops like aten.cat (see https://github.com/pytorch/pytorch/blob/main/torch/_inductor/lowering.py#L1093). This is not allowed in MIGraphX so we need insert explicit converts in these cases.

Conversion of https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0 is affected by this issue.