### PR TITLE
fix convert_pt2e call for pytorch > 2.2

### DIFF
--- a/py/torch_migraphx/fx/converters/quant_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/quant_ops_converters.py
@@ -113,7 +113,13 @@ def aten_ops_quantize_per_channel(mgx_module, node, args, kwargs):
 def aten_ops_dequantize(mgx_module, node, args, kwargs):
     assert len(args) >= 6
     q_inp = args[0]
-    assert q_inp.qparams is not None
+
+    if q_inp.qparams is None:
+        raise RuntimeError("""
+            Graph contains a dequantize operation without a preceding quantize operation.
+            If using torch.ao.quantization.quantize_pt2e.convert_pt2e with PyTorch >= 2.2,
+            call using fold_quantize=False.
+            """)
 
     qparams = q_inp.qparams
     dq_ins = add_dequantize_linear(mgx_module, q_inp.instr_ref,

--- a/tests/dynamo/quantization/quantization_utils_dynamo.py
+++ b/tests/dynamo/quantization/quantization_utils_dynamo.py
@@ -1,3 +1,4 @@
+from packaging import version
 import torch_migraphx
 import torch
 
@@ -24,6 +25,16 @@ class FuncModule(torch.nn.Module):
         return self.func(x, *self.args, **self.kwargs)
 
 
+def stable_convert_pt2e(model, use_reference_representation=False):
+    print(torch.__version__)
+    if version.parse(torch.__version__) < version.parse("2.2"):
+        return convert_pt2e(model, use_reference_representation)
+    else:
+        return convert_pt2e(model,
+                            use_reference_representation,
+                            fold_quantize=False)
+
+
 def quantize_module(mod, inp_shapes, asymm=False, calibration_n=10):
     quantizer = MGXQuantizer(asymmetric_activations=asymm)
 
@@ -35,7 +46,7 @@ def quantize_module(mod, inp_shapes, asymm=False, calibration_n=10):
         inps = [torch.randn(*s) for s in inp_shapes]
         model_prepared(*inps)
 
-    return convert_pt2e(model_prepared)
+    return stable_convert_pt2e(model_prepared)
 
 
 def move_q_gm_to_device(gm, device="cuda"):


### PR DESCRIPTION
convert_pt2e api changed in torch 2.2 causing test case failures