### PR TITLE
add converter for sqrt function

### DIFF
--- a/py/torch_migraphx/fx/converters/aten_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/aten_ops_converters.py
@@ -387,6 +387,13 @@ def aten_ops_log_softmax(mgx_module, node, args, _kwargs):
     acc_kwargs = {"input": args[0], "dim": args[1]}
 
     return acc_ops_converters.acc_ops_log_softmax(mgx_module, node, (), acc_kwargs)
+ 
+ 
+@migraphx_converter(torch.ops.aten.sqrt.default)
+def aten_ops_sqrt(mgx_module, node, args, kwargs):
+    assert len(args) == 1
+    acc_kwargs = {"input": args[0]}
+    return acc_ops_converters.acc_ops_sqrt(mgx_module, node, (), acc_kwargs)
 
 
 @migraphx_converter(torch.ops.aten.sin.default)

--- a/tests/dynamo/converters/test_pointwise_ops_dynamo.py
+++ b/tests/dynamo/converters/test_pointwise_ops_dynamo.py
@@ -12,6 +12,7 @@ if not hasattr(torch_migraphx, "dynamo"):
     torch.ops.aten.cos.default,
     torch.ops.aten.exp.default,
     torch.ops.aten.neg.default,
+    torch.ops.aten.sqrt.default,
 ])
 def test_unary_func(op_alias):
     inp = torch.randn(2, 9, 11, 1).cuda()


### PR DESCRIPTION
Converts a `sqrt` op from the ATen function set to the migraphx `sqrt` op.  Closes Issue #115 