### PR TITLE
add explicit conversion of min and max in clamp converter

### DIFF
--- a/py/torch_migraphx/fx/converters/acc_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/acc_ops_converters.py
@@ -127,13 +127,13 @@ def acc_ops_clamp(mgx_module, node, args, kwargs):
             'max'] if 'max' in kwargs and kwargs['max'] is not None else 1e16
 
     if isinstance(min_val, MGXInstruction):
-        min_mgx = min_val.instr_ref
+        min_mgx = convert_arg(mgx_module, min_val.instr_ref, dtype)
     else:
         min_mgx = mgx_module.add_literal(
             torch.tensor([min_val], dtype=dtype).numpy())
 
     if isinstance(max_val, MGXInstruction):
-        max_mgx = max_val.instr_ref
+        max_mgx = convert_arg(mgx_module, max_val.instr_ref, dtype)
     else:
         max_mgx = mgx_module.add_literal(
             torch.tensor([max_val], dtype=dtype).numpy())

--- a/tests/dynamo/converters/test_activations_dynamo.py
+++ b/tests/dynamo/converters/test_activations_dynamo.py
@@ -7,8 +7,9 @@ if not hasattr(torch_migraphx, "dynamo"):
     pytest.skip(allow_module_level=True)
 
 
-@pytest.mark.parametrize('op_alias', [torch.ops.aten.clamp.default,
-                                      torch.ops.aten.hardtanh.default])
+@pytest.mark.parametrize(
+    'op_alias',
+    [torch.ops.aten.clamp.default, torch.ops.aten.hardtanh.default])
 @pytest.mark.parametrize('inp_size', [(4, 2, 7), (128, 2048),
                                       (1, 3, 6, 128, 128)])
 def test_clamp(op_alias, inp_size):
@@ -20,18 +21,23 @@ def test_clamp(op_alias, inp_size):
 
 
 @pytest.mark.parametrize('op_alias', [torch.ops.aten.clamp.Tensor])
-@pytest.mark.parametrize('inp_size', [(4, 2, 7), (128, 2048),
-                                      (1, 3, 6, 128, 128)])
-def test_clamp_tensor(op_alias, inp_size):
+@pytest.mark.parametrize('inp_size, inp_type',
+                         [((4, 2, 7), torch.float32),
+                          ((128, 2048), torch.float16),
+                          ((1, 3, 6, 128, 128), torch.float32)])
+def test_clamp_tensor(op_alias, inp_size, inp_type):
     min_, max_ = randbounds(-1, 1)
-    inp = torch.randn(inp_size).cuda()
-    mod = FuncModule(op_alias, torch.tensor(min_).cuda(), torch.tensor(max_).cuda()).cuda()
+    inp = torch.randn(inp_size, dtype=inp_type).cuda()
+    mod = FuncModule(op_alias,
+                     torch.tensor(min_).cuda(),
+                     torch.tensor(max_).cuda()).cuda()
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
 
 
-@pytest.mark.parametrize('op_alias', [torch.ops.aten.clamp_min.default,
-                                      torch.ops.aten.clamp_max.default])
+@pytest.mark.parametrize(
+    'op_alias',
+    [torch.ops.aten.clamp_min.default, torch.ops.aten.clamp_max.default])
 @pytest.mark.parametrize('inp_size', [(4, 2, 7), (128, 2048),
                                       (1, 3, 6, 128, 128)])
 def test_clamp_min_max(op_alias, inp_size):
@@ -42,8 +48,9 @@ def test_clamp_min_max(op_alias, inp_size):
     verify_outputs(mod, mgx_mod, inp)
 
 
-@pytest.mark.parametrize('op_alias', [torch.ops.aten.clamp_min.Tensor,
-                                      torch.ops.aten.clamp_max.Tensor])
+@pytest.mark.parametrize(
+    'op_alias',
+    [torch.ops.aten.clamp_min.Tensor, torch.ops.aten.clamp_max.Tensor])
 @pytest.mark.parametrize('inp_size', [(4, 2, 7), (128, 2048),
                                       (1, 3, 6, 128, 128)])
 def test_clamp_min_max_tensor(op_alias, inp_size):


### PR DESCRIPTION
See linked issue.

aten.clamp.Tensor seems to be doing implicit conversions of min and max tensors.