### PR TITLE
add min migraphx version parameter to register_converter decorator

### DIFF
--- a/py/torch_migraphx/fx/converter_registry.py
+++ b/py/torch_migraphx/fx/converter_registry.py
@@ -1,20 +1,20 @@
 #####################################################################################
 # Copyright (c) 2022-present, Advanced Micro Devices, Inc. All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice, this
 #    list of conditions and the following disclaimer.
-# 
+#
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # 3. Neither the name of the copyright holder nor the names of its
 #    contributors may be used to endorse or promote products derived from
 #    this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,18 +26,31 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #####################################################################################
+from packaging import version
 from torch.fx.node import Target
+import migraphx
+
+# For old MIGraphX dev builds, there is no way to obtain proper version information
+# default this to 2.10 because this issue is resolved from 2.11.0 and onward
+MIGRAPHX_VERSION = migraphx.__version__ if migraphx.__version__ != "dev" else "2.10"
 
 CONVERTERS = {}
 
 
-def migraphx_converter(target: Target, enabled: bool = True):
+def migraphx_converter(target: Target,
+                       enabled: bool = True,
+                       min_migraphx_ver=None):
+
     def register_converter(fn):
         CONVERTERS[target] = fn
         return fn
 
     def disable_converter(fn):
         return fn
+
+    if (min_migraphx_ver and version.parse(MIGRAPHX_VERSION)
+            < version.parse(min_migraphx_ver)):
+        return disable_converter
 
     if enabled:
         return register_converter

--- a/py/torch_migraphx/fx/converter_registry.py
+++ b/py/torch_migraphx/fx/converter_registry.py
@@ -39,7 +39,7 @@ CONVERTERS = {}
 
 def migraphx_converter(target: Target,
                        enabled: bool = True,
-                       min_migraphx_ver=None):
+                       min_migraphx_ver: str = None):
 
     def register_converter(fn):
         CONVERTERS[target] = fn


### PR DESCRIPTION
Add ability to disable a converter based on installed MIGraphX version. This is useful when a required op in migraphx is not available in older versions.