### PR TITLE
support scalar shaped tensor input to masked fill

### DIFF
--- a/py/torch_migraphx/fx/converters/acc_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/acc_ops_converters.py
@@ -1166,9 +1166,13 @@ def acc_ops_masked_fill(mgx_module, node, args, kwargs):
     inp, mask, value = kwargs["input"], kwargs["mask"], kwargs["value"]
     assert all(not i.is_quantized() for i in (inp, mask))
 
-    dtype = get_arg_dtype(inp)
-    value_mgx = mgx_module.add_literal(
-        torch.tensor(value, dtype=dtype).numpy())
+    dtype = get_arg_dtype(inp.instr_ref)
+    if isinstance(value, MGXInstruction):
+        assert value.shape().scalar()
+        value_mgx = convert_arg(mgx_module, value.instr_ref, dtype)
+    else:
+        value_mgx = mgx_module.add_literal(
+            torch.tensor(value, dtype=dtype).numpy())
 
     new_kwargs = {
         "input": MGXInstruction(value_mgx),

--- a/py/torch_migraphx/fx/converters/aten_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/aten_ops_converters.py
@@ -113,6 +113,7 @@ def aten_ops_where(mgx_module, node, args, kwargs):
 
 
 @migraphx_converter(torch.ops.aten.masked_fill.Scalar)
+@migraphx_converter(torch.ops.aten.masked_fill.Tensor)
 def aten_ops_masked_fill(mgx_module, node, args, kwargs):
     assert len(args) == 3
 

--- a/tests/dynamo/converters/test_bool_ops_dynamo.py
+++ b/tests/dynamo/converters/test_bool_ops_dynamo.py
@@ -19,11 +19,13 @@ def test_where(op_alias):
     verify_outputs(mod, mgx_mod, cond)
 
 
-@pytest.mark.parametrize('op_alias', [torch.ops.aten.masked_fill.Scalar])
-def test_masked_fill(op_alias):
-    inp = torch.randn(32, 43, 11, 2, 1).cuda()
-    mask = torch.randn(1, 43, 11, 1, 1).cuda() > 0
-    value = 2
+@pytest.mark.parametrize('op_alias, value', [
+    (torch.ops.aten.masked_fill.Scalar, 2),
+    (torch.ops.aten.masked_fill.Tensor, torch.tensor(5)),
+])
+def test_masked_fill(op_alias, value):
+    inp = torch.randn(4, 7, 3, 2, 1).cuda()
+    mask = torch.randn(1, 7, 3, 1, 1).cuda() > 0
 
     mod = FuncModule(op_alias, mask, value).cuda()
 

--- a/tests/fx/converters/test_bool_ops_fx.py
+++ b/tests/fx/converters/test_bool_ops_fx.py
@@ -14,10 +14,10 @@ def test_where():
     verify_outputs(mod, mgx_mod, cond)
 
 
-def test_masked_fill():
-    inp = torch.randn(32, 43, 11, 2, 1)
-    mask = torch.randn(1, 43, 11, 1, 1) > 0
-    value = 2
+@pytest.mark.parametrize("value", [2, 0.4, torch.tensor(3)])
+def test_masked_fill(value):
+    inp = torch.randn(4, 6, 3, 2, 1)
+    mask = torch.randn(1, 6, 3, 1, 1) > 0
 
     mod = MethodModule("masked_fill", mask=mask, value=value)
 


### PR DESCRIPTION
Original acc converter impl missed supported a scalar shaped tensor input for value (not clear in https://pytorch.org/docs/stable/generated/torch.Tensor.masked_fill_.html that its a valid input, but it works in code).

Added support for that and added the aten Tensor overload mapping to the same converter.