### PR TITLE
Added aten converter for the unary op "floor"

### DIFF
--- a/py/torch_migraphx/fx/converters/aten_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/aten_ops_converters.py
@@ -1032,6 +1032,14 @@ def aten_ops_le(mgx_module, node, args, kwargs):
     return acc_ops_converters.acc_ops_le(mgx_module, node, (), acc_kwargs)
 
 
+@migraphx_converter(torch.ops.aten.floor.default)
+def aten_ops_floor(mgx_module, node, args, kwargs):
+    assert len(args) == 1
+    acc_kwargs = {"input": args[0]}
+
+    return acc_ops_converters.acc_ops_floor(mgx_module, node, (), acc_kwargs)
+
+
 @migraphx_converter(torch.ops.aten.neg.default)
 def aten_ops_neg(mgx_module, node, args, kwargs):
     assert len(args) == 1

--- a/tests/dynamo/converters/test_pointwise_ops_dynamo.py
+++ b/tests/dynamo/converters/test_pointwise_ops_dynamo.py
@@ -11,6 +11,7 @@ if not hasattr(torch_migraphx, "dynamo"):
     torch.ops.aten.abs.default,
     torch.ops.aten.cos.default,
     torch.ops.aten.exp.default,
+    torch.ops.aten.floor.default,
     torch.ops.aten.neg.default,
     torch.ops.aten.reciprocal.default,
     torch.ops.aten.sin.default,


### PR DESCRIPTION
Simple task, unary op. with an existing acc implementation.  The new converter and test follow a common pattern.
