### PR TITLE
Support linalg_vector_norm

### DIFF
--- a/py/torch_migraphx/fx/converters/aten_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/aten_ops_converters.py
@@ -669,6 +669,26 @@ def aten_ops_group_norm(mgx_module, node, args, kwargs):
 
     return acc_ops_converters.acc_ops_group_norm(mgx_module, node, (),
                                                  acc_kwargs), None, None
+    
+
+@migraphx_converter(torch.ops.aten.linalg_vector_norm.default)
+def aten_ops_linalg_vector_norm(mgx_module, node, args, kwargs):
+    assert len(args) >= 1
+
+    acc_kwargs = {
+        "input": args[0],
+        "ord": args[1] if len(args) >= 2 else 2,
+        "dim": args[2] if len(args) >= 3 else None,
+        "keepdim": args[3] if len(args) >= 4 else False,
+    }
+    
+    # For dim the aten type is: int[1]? dim=None. Unfold int[1] to scalar
+    if isinstance(acc_kwargs["dim"], (list, tuple)):
+        assert len(acc_kwargs["dim"]) == 1
+        acc_kwargs["dim"] = acc_kwargs["dim"][0]
+
+    return acc_ops_converters.acc_ops_linalg_vector_norm(
+        mgx_module, node, (), acc_kwargs)
 
 
 @migraphx_converter(torch.ops.aten.convolution.default)

--- a/py/torch_migraphx/fx/converters/aten_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/aten_ops_converters.py
@@ -689,6 +689,13 @@ def aten_ops_linalg_vector_norm(mgx_module, node, args, kwargs):
         "keepdim": args[3] if len(args) >= 4 else False,
     }
     
+    # Aten op decelaration:
+    # aten::linalg_vector_norm(Tensor self, 
+    #                          Scalar ord=2, 
+    #                          int[1]? dim=None, 
+    #                          bool keepdim=False, 
+    #                          *, 
+    #                          ScalarType? dtype=None) -> Tensor
     # For dim the aten type is: int[1]? dim=None. Unfold int[1] to scalar
     if isinstance(acc_kwargs["dim"], (list, tuple)):
         assert len(acc_kwargs["dim"]) == 1

--- a/py/torch_migraphx/fx/tracer/acc_tracer/acc_ops.py
+++ b/py/torch_migraphx/fx/tracer/acc_tracer/acc_ops.py
@@ -616,6 +616,12 @@ def linalg_norm(*, input, ord, dim, keepdim):
     return torch.linalg.norm(input=input, ord=ord, dim=dim, keepdim=keepdim)
 
 
+@register_acc_op_mapping(op_and_target=("call_function", torch.linalg.vector_norm))
+@register_acc_op
+def linalg_vector_norm(*, input, ord, dim, keepdim):
+    return torch.linalg.vector_norm(input=input, ord=ord, dim=dim, keepdim=keepdim)
+
+
 @register_acc_op_mapping(
     op_and_target=("call_function", torch.cumsum),
     arg_replacement_tuples=[

--- a/tests/dynamo/converters/test_linalg_ops_dynamo.py
+++ b/tests/dynamo/converters/test_linalg_ops_dynamo.py
@@ -17,6 +17,7 @@ if not hasattr(torch_migraphx, "dynamo"):
     (2, 1, True),
     (0.5,),
     (4.3, None, True),
+    (),
 ])
 def test_linalg_vector_norm(op_alias, args):
     inp = torch.randn(9, 3, 6, 2).cuda()

--- a/tests/dynamo/converters/test_linalg_ops_dynamo.py
+++ b/tests/dynamo/converters/test_linalg_ops_dynamo.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+from dynamo_test_utils import FuncModule, convert_to_mgx, verify_outputs
+import torch_migraphx
+
+if not hasattr(torch_migraphx, "dynamo"):
+    pytest.skip(allow_module_level=True)
+
+@pytest.mark.parametrize('op_alias',
+                         [torch.ops.aten.linalg_vector_norm.default])
+# args are: ord, dim, keepdim
+@pytest.mark.parametrize('args', [
+    (0,),
+    (1, None, False),
+    (torch.inf, 0),
+    (-torch.inf, -1, True),
+    (2, 1, True),
+    (0.5,),
+    (4.3, None, True),
+])
+def test_linalg_vector_norm(op_alias, args):
+    inp = torch.randn(9, 3, 6, 2).cuda()
+    mod = FuncModule(op_alias, *args)
+
+    mgx_mod = convert_to_mgx(mod, [inp])
+    verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_linalg_ops_fx.py
+++ b/tests/fx/converters/test_linalg_ops_fx.py
@@ -25,3 +25,10 @@ def test_linalg_vector_norm(ord, dim, keepdim):
                      keepdim=keepdim)
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
+
+
+def test_linalg_vector_norm_defaults():
+    inp = torch.randn(4, 6, 3, 2)
+    mod = FuncModule(torch.linalg.vector_norm)
+    mgx_mod = convert_to_mgx(mod, [inp])
+    verify_outputs(mod, mgx_mod, inp)

--- a/tests/fx/converters/test_linalg_ops_fx.py
+++ b/tests/fx/converters/test_linalg_ops_fx.py
@@ -1,8 +1,27 @@
 import pytest
 import torch
-from fx_test_utils import convert_to_mgx, verify_outputs
+from fx_test_utils import FuncModule, convert_to_mgx, verify_outputs
 
 
 @pytest.mark.skip(reason="linalg.norm converter not implemented")
 def test_linalg_norm():
     pass
+
+
+@pytest.mark.parametrize('ord, dim, keepdim', [
+    (0, None, False),
+    (1, None, True),
+    (torch.inf, 0, False),
+    (-torch.inf, -1, True),
+    (2, 1, True),
+    (2.5, 2, False),
+    (4.3, None, True),
+])
+def test_linalg_vector_norm(ord, dim, keepdim):
+    inp = torch.randn(4, 6, 3, 2)
+    mod = FuncModule(torch.linalg.vector_norm,
+                     ord=ord,
+                     dim=dim,
+                     keepdim=keepdim)
+    mgx_mod = convert_to_mgx(mod, [inp])
+    verify_outputs(mod, mgx_mod, inp)


### PR DESCRIPTION
Implements converter for https://pytorch.org/docs/stable/generated/torch.linalg.vector_norm.html