### PR TITLE
add converters for logical_not, for both aten and acc.  Includes tests

### DIFF
--- a/py/torch_migraphx/fx/converters/acc_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/acc_ops_converters.py
@@ -325,6 +325,16 @@ def acc_ops_abs(mgx_module, node, args, kwargs):
                           qparams=inp.qparams)
 
 
+@migraphx_converter(acc_ops.logical_not)
+def acc_ops_logical_not(mgx_module, node, args, kwargs):
+    inp = kwargs["input"]
+    inp_bool = mgx_module.add_instruction(
+        migraphx.op('convert',  target_type=migraphx.shape.type_t.bool_type),
+        [inp.instr_ref])
+    return MGXInstruction(mgx_module.add_instruction(migraphx.op('not'),
+                                                     [inp_bool]))
+
+
 @migraphx_converter(acc_ops.neg)
 def acc_ops_neg(mgx_module, node, args, kwargs):
     inp = kwargs["input"]

--- a/py/torch_migraphx/fx/converters/acc_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/acc_ops_converters.py
@@ -328,11 +328,8 @@ def acc_ops_abs(mgx_module, node, args, kwargs):
 @migraphx_converter(acc_ops.logical_not)
 def acc_ops_logical_not(mgx_module, node, args, kwargs):
     inp = kwargs["input"]
-    inp_bool = mgx_module.add_instruction(
-        migraphx.op('convert',  target_type=migraphx.shape.type_t.bool_type),
-        [inp.instr_ref])
-    return MGXInstruction(mgx_module.add_instruction(migraphx.op('not'),
-                                                     [inp_bool]))
+    return MGXInstruction(mgx_module.add_instruction(migraphx.op('not'), [inp.instr_ref]),
+                          bool_output=True)
 
 
 @migraphx_converter(acc_ops.neg)

--- a/py/torch_migraphx/fx/converters/aten_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/aten_ops_converters.py
@@ -461,6 +461,13 @@ def aten_ops_log_softmax(mgx_module, node, args, _kwargs):
     return acc_ops_converters.acc_ops_log_softmax(mgx_module, node, (), acc_kwargs)
 
 
+@migraphx_converter(torch.ops.aten.logical_not.default)
+def aten_ops_logical_not(mgx_module, node, args, kwargs):
+    assert len(args) == 1
+    acc_kwargs = {"input": args[0]}
+    return acc_ops_converters.logical_not(mgx_module, node, (), acc_kwargs)
+
+
 @migraphx_converter(torch.ops.aten.reciprocal.default)
 def aten_ops_reciprocal(mgx_module, node, args, kwargs):
     assert len(args) == 1
@@ -1030,6 +1037,14 @@ def aten_ops_le(mgx_module, node, args, kwargs):
 
     acc_kwargs = {"input": inp, "other": other}
     return acc_ops_converters.acc_ops_le(mgx_module, node, (), acc_kwargs)
+
+
+@migraphx_converter(torch.ops.aten.logical_not.default)
+def aten_ops_logical_not(mgx_module, node, args, kwargs):
+    assert len(args) == 1
+    acc_kwargs = {"input": args[0]}
+
+    return acc_ops_converters.acc_ops_logical_not(mgx_module, node, (), acc_kwargs)
 
 
 @migraphx_converter(torch.ops.aten.neg.default)

--- a/py/torch_migraphx/fx/tracer/acc_tracer/acc_ops.py
+++ b/py/torch_migraphx/fx/tracer/acc_tracer/acc_ops.py
@@ -1237,6 +1237,13 @@ def abs(*, input):
 
 
 @register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.logical_not))
+@register_acc_op
+def logical_not(*, input):
+    return torch.logical_not(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
 @register_acc_op_mapping(op_and_target=("call_function", operator.neg))
 @register_acc_op_mapping(op_and_target=("call_function", torch.neg))
 @register_acc_op

--- a/tests/dynamo/converters/test_pointwise_ops_dynamo.py
+++ b/tests/dynamo/converters/test_pointwise_ops_dynamo.py
@@ -23,6 +23,19 @@ def test_unary_func(op_alias):
     verify_outputs(mod, mgx_mod, inp, equal_nan=True)
 
 
+@pytest.mark.parametrize('op_alias', [torch.ops.aten.logical_not.default,])
+@pytest.mark.parametrize('input', [
+    [1, 0],
+    [True, False],
+    [1., 0.],
+])
+def test_pointwise_not(op_alias, input):
+    inp = torch.Tensor(input).cuda()
+    mod = FuncModule(op_alias).cuda()
+    mgx_mod = convert_to_mgx(mod, [inp])
+    verify_outputs(mod, mgx_mod, inp)
+
+
 @pytest.mark.parametrize('op_alias', [torch.ops.aten.addcmul.default])
 @pytest.mark.parametrize('in_shape, m1_shape, m2_shape, value', [
     ((32, 24), (1, 24), (32, 1), -2),

--- a/tests/fx/converters/test_pointwise_ops_fx.py
+++ b/tests/fx/converters/test_pointwise_ops_fx.py
@@ -71,6 +71,19 @@ def test_unary_func(oper):
     verify_outputs(mod, mgx_mod, inp, equal_nan=True)
 
 
+@pytest.mark.parametrize('oper', [torch.logical_not,])
+@pytest.mark.parametrize('input', [
+    [1, 0],
+    [True, False],
+    [1., 0.],
+])
+def test_pointwise_not(oper, input):
+    inp = torch.Tensor(input)
+    mod = FuncModule(oper)
+    mgx_mod = convert_to_mgx(mod, [inp])
+    verify_outputs(mod, mgx_mod, inp)
+
+
 @pytest.mark.parametrize('oper', [torch.log, torch.log1p])
 def test_log(oper):
     inp = torch.abs(torch.randn(2, 9, 11, 1))


### PR DESCRIPTION
The main difference between the Torch `logical_not` ops and Migraphx' `not` is that MigraphX returns 0 or 1 in the original datatype, while the Torch ops always return Booleans.