### PR TITLE
add requirements file to tools/perf scripts

### DIFF
--- a/tools/perf/requirements.txt
+++ b/tools/perf/requirements.txt
@@ -1,0 +1,1 @@
+transformers<4.42


### PR DESCRIPTION
restricting transformers version, seems to be a breakage when using new transformers version with torch >= 2.3