### PR TITLE
propagate "bool_output" flag through shape ops

### DIFF
--- a/tests/fx/converters/test_shape_ops_fx.py
+++ b/tests/fx/converters/test_shape_ops_fx.py
@@ -19,7 +19,9 @@ class StackModule(FuncModule):
 class BoolOpModule(FuncModule):
 
     def forward(self, x1, x2):
-        gt = x1.gt(x2)  # Func thats not represented as bool in migraphx
+        # In MIGraphX the output type of logical ops is the same as the input types. 
+        # This tests that the output is properly converted to bool_type
+        gt = x1.gt(x2)
         return self.func(gt, *self.args, **self.kwargs)
 
 


### PR DESCRIPTION
Comparison ops in MIGraphX do not output `bool_type` (it keeps the input datatype). Eg. the `greater` op in migraphx will output `float_type` is the inputs are `float_type`.

This is problematic when such an op is an output node. Ie. The migraphx output will be `float_type` in the above case, where torch-migraphx expects `bool_type`. We have a `bool_output` flag that is set by ops that are affected by this problem. However, if there are any shape ops (eg. reshape, transpose, etc), this flag isnt propagated currently.

See added test case: a bool op (eg. torch.Tensor.gt) followed by a shape op fails without this change. 