### PR TITLE
support zeros_like and add test cases for remove_ops pass

### DIFF
--- a/py/torch_migraphx/dynamo/passes/remove_ops.py
+++ b/py/torch_migraphx/dynamo/passes/remove_ops.py
@@ -102,13 +102,18 @@ def remove_const_ops(gm: torch.fx.GraphModule, device: str = "cuda"):
         const_ops = {
             torch.ops.aten.full_like.default: torch.full,
             torch.ops.aten.full.default: torch.full,
+            torch.ops.aten.zeros_like.default: torch.full,
         }
         for node in gm.graph.nodes:
             if node.op == "call_function" and node.target in const_ops.keys():
                 og_node = node
                 size = og_node.meta['tensor_meta'].shape
                 dtype = og_node.meta['tensor_meta'].dtype
-                value = node.args[1]
+                
+                if node.target == torch.ops.aten.zeros_like.default:
+                    value = 0
+                else:
+                    value = node.args[1]
                 const_tensor = const_ops[node.target](size,
                                                       value,
                                                       dtype=dtype,

--- a/py/torch_migraphx/dynamo/passes/remove_ops.py
+++ b/py/torch_migraphx/dynamo/passes/remove_ops.py
@@ -108,12 +108,9 @@ def remove_const_ops(gm: torch.fx.GraphModule, device: str = "cuda"):
             if node.op == "call_function" and node.target in const_ops.keys():
                 og_node = node
                 size = og_node.meta['tensor_meta'].shape
-                dtype = og_node.meta['tensor_meta'].dtype
-                
-                if node.target == torch.ops.aten.zeros_like.default:
-                    value = 0
-                else:
-                    value = node.args[1]
+                dtype = og_node.meta['tensor_meta'].dtype   
+                value = 0 if node.target == torch.ops.aten.zeros_like.default else node.args[1]
+
                 const_tensor = const_ops[node.target](size,
                                                       value,
                                                       dtype=dtype,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,10 @@ def pytest_make_parametrize_id(config, val, argname):
         val = val.__name__
     elif isinstance(val, torch.nn.Module):
         val = val._get_name()
-    return f'{argname}={str(val)}'
+    val_str = str(val)
+    if len(val_str) > 50:
+        val_str = type(val)
+    return f'{argname}={val_str}'
 
 
 @pytest.fixture

--- a/tests/dynamo/passes/dynamo_passes_test_utils.py
+++ b/tests/dynamo/passes/dynamo_passes_test_utils.py
@@ -1,0 +1,53 @@
+import torch
+from torch.fx.passes.shape_prop import ShapeProp
+
+
+def generate_func_gm(func,
+                     inputs=None,
+                     constants=None,
+                     args=None,
+                     kwargs=None):
+    """
+    func: callable torch function to be tested
+    inputs: dict of int:torch.Tensor values. 
+            Keys are the position in which to pass the input to func. 
+            Values are example input tensors
+    constants: dict of int:torch.Tensor values. 
+               Keys are the position in which to pass the constant to func. 
+               Values are constant tensors
+    args, kwargs: any additional args and kwargs to pass to func
+    
+    Returns:
+        GraphModule with call_function node targetting func, and necessary 
+            placeholder, get_attr, and output nodes. Input tensors are used 
+            to run shape prop and populate tensor_meta values for each node
+    """
+    g = torch.fx.Graph()
+
+    const_nodes = {}
+    args_list = list(args) if args else []
+    inputs = {} if inputs == None else inputs
+    constants = {} if constants == None else constants
+    kwargs = {} if kwargs == None else kwargs
+
+    for k, v in inputs.items():
+        in_k = g.placeholder(f"x{k}")
+        args_list.insert(k, in_k)
+
+    for k, v in constants.items():
+        c_k = g.get_attr(f"c{k}")
+        const_nodes[f"c{k}"] = v
+        args_list.insert(k, c_k)
+
+    func_node = g.call_function(func, args=tuple(args_list), kwargs=kwargs)
+    g.output(func_node)
+
+    gm = torch.fx.GraphModule(const_nodes, g)
+    sp = ShapeProp(gm)
+    sp.propagate(*inputs.values())
+
+    return gm
+
+
+def target_exists_in_graph(gm, target):
+    return any(node.target == target for node in gm.graph.nodes)

--- a/tests/dynamo/passes/test_remove_const_ops.py
+++ b/tests/dynamo/passes/test_remove_const_ops.py
@@ -1,0 +1,84 @@
+import pytest
+import torch
+import torch_migraphx
+from torch_migraphx.dynamo.passes.remove_ops import remove_const_ops
+from dynamo_passes_test_utils import generate_func_gm, target_exists_in_graph
+
+
+@pytest.mark.parametrize(
+    'func, inputs, args, kwargs',
+    [
+        (
+            # Creates tensor of 0s where dtype is the dtype of the input, and
+            # size is specified in the args
+            torch.ops.aten.new_zeros.default,
+            {
+                0: torch.randn(3, 4, 2)
+            },
+            ((2, 6), ),
+            {},
+        ),
+        (
+            # Creates tensor of 1s where dtype is the dtype of the input, and
+            # size is specified in the args
+            torch.ops.aten.new_ones.default,
+            {
+                0: torch.randn(3, 4, 2)
+            },
+            ((2, 6), ),
+            {},
+        ),
+        (
+            # Creates tensor where each element is `value` specified in args,
+            # size and dtpye is the same as that of the input
+            torch.ops.aten.full_like.default,
+            {
+                0: torch.randn(3, 4, 2)
+            },
+            (2.3, ),
+            {},
+        ),
+        (
+            # Creates tensor where each element is `value` specified in args,
+            # and the shape is also specified in args, dtype is an optional kwarg
+            torch.ops.aten.full.default,
+            {},
+            ((2, 4, 5), 3.2),
+            {},
+        ),
+        (
+            torch.ops.aten.full.default,
+            {},
+            ((2, 4, 5), 3.2),
+            {
+                "dtype": torch.half
+            },
+        ),
+        (
+            # Creates tensor of 0s, size and dtpye is the same as that of the input
+            torch.ops.aten.zeros_like.default,
+            {
+                0: torch.randn(3, 4, 2)
+            },
+            (),
+            {},
+        ),
+        (
+            # Creates vector similar to using python the `range`` generator
+            torch.ops.aten.arange.start,
+            {},
+            (1, 5),  # Takes start, end as args
+            {},
+        ),
+    ])
+def test_remove_const_ops(func, inputs, args, kwargs):
+    gm = generate_func_gm(func=func, inputs=inputs, args=args, kwargs=kwargs)
+    gold_out = gm(*inputs.values())
+
+    pass_gm = remove_const_ops(gm, device="cpu")
+    pass_out = pass_gm(*inputs.values())
+
+    # The outputs should be equal, and the target function should be
+    # removed from the graph
+    assert torch.equal(gold_out, pass_out)
+    assert not target_exists_in_graph(pass_gm, func)


### PR DESCRIPTION
Merge #172 first: the simplification added here exposes a bug in some models that is fixed by that PR

This PR:
1. Add tests for the remove_ops pass that is run in the dynamo workflow
2. Add simplification to remove `torch.ops.aten.zeros_like.default` and replace it with a constant tensor instead