### PR TITLE
add aten.fill converter

### DIFF
--- a/py/torch_migraphx/fx/converters/aten_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/aten_ops_converters.py
@@ -124,7 +124,7 @@ def aten_ops_masked_fill(mgx_module, node, args, kwargs):
 
 @migraphx_converter(torch.ops.aten.fill.Scalar)
 @migraphx_converter(torch.ops.aten.fill.Tensor)
-def aten_ops_masked_fill(mgx_module, node, args, kwargs):
+def aten_ops_fill(mgx_module, node, args, kwargs):
     assert len(args) == 2
 
     mask_mgx = MGXInstruction(mgx_module.add_literal(torch.tensor(True).numpy()))

--- a/py/torch_migraphx/fx/converters/aten_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/aten_ops_converters.py
@@ -122,6 +122,17 @@ def aten_ops_masked_fill(mgx_module, node, args, kwargs):
                                                   acc_kwargs)
 
 
+@migraphx_converter(torch.ops.aten.fill.Scalar)
+@migraphx_converter(torch.ops.aten.fill.Tensor)
+def aten_ops_masked_fill(mgx_module, node, args, kwargs):
+    assert len(args) == 2
+
+    mask_mgx = MGXInstruction(mgx_module.add_literal(torch.tensor(True).numpy()))
+    acc_kwargs = {"input": args[0], "mask": mask_mgx, "value": args[1]}
+    return acc_ops_converters.acc_ops_masked_fill(mgx_module, node, (),
+                                                  acc_kwargs)
+
+
 @migraphx_converter(torch.ops.aten.slice_scatter.default)
 def aten_ops_slice_scatter(mgx_module, node, args, kwargs):
     assert len(args) >= 2

--- a/tests/dynamo/converters/test_bool_ops_dynamo.py
+++ b/tests/dynamo/converters/test_bool_ops_dynamo.py
@@ -32,6 +32,17 @@ def test_masked_fill(op_alias, value):
     mgx_mod = convert_to_mgx(mod, [inp])
     verify_outputs(mod, mgx_mod, inp)
 
+@pytest.mark.parametrize('op_alias, value', [
+    (torch.ops.aten.fill.Scalar, 2),
+    (torch.ops.aten.fill.Tensor, torch.tensor(5)),
+])
+def test_fill(op_alias, value):
+    inp = torch.randn(4, 7, 3, 2, 1).cuda()
+    mod = FuncModule(op_alias, value).cuda()
+
+    mgx_mod = convert_to_mgx(mod, [inp])
+    verify_outputs(mod, mgx_mod, inp)
+
 
 @pytest.mark.parametrize('op_alias', [
     torch.ops.aten.eq.Tensor,


### PR DESCRIPTION
Using masked_fill migraphx op for now. Can be updated to use a new fill op if migraphx supports it in the future.