### PR TITLE
avoid adding 0-dim tensors in gather

### DIFF
--- a/tests/dynamo/converters/test_gather_dynamo.py
+++ b/tests/dynamo/converters/test_gather_dynamo.py
@@ -3,6 +3,19 @@ import torch
 import numpy as np
 from dynamo_test_utils import FuncModule, convert_to_mgx, verify_outputs
 
+
+class GatherModule(torch.nn.Module):
+
+    def __init__(self, op_alias, dim):
+        super(GatherModule, self).__init__()
+        self.op_alias = op_alias
+        self.dim = dim
+
+    def forward(self, x, idx):
+        return self.op_alias(x, self.dim, idx)
+
+
+@pytest.mark.parametrize('op_alias', [torch.ops.aten.gather.default])
 @pytest.mark.parametrize("input_dim, dim", [((3, 3), 0), 
                                             ((3, 3), 1), 
                                             ((3, 3), -1), 
@@ -10,7 +23,7 @@ from dynamo_test_utils import FuncModule, convert_to_mgx, verify_outputs
                                             ((10, 5), -2), 
                                             ((2, 3, 4, 5, 6), -3),
                                             ((2, 3, 4, 5, 6), -4)])
-def test_gather(input_dim, dim):
+def test_gather(op_alias, input_dim, dim):
     input = torch.rand(input_dim).cuda()
 
     dim_size = input.size(dim)
@@ -18,7 +31,7 @@ def test_gather(input_dim, dim):
     index_shape[dim] = np.random.randint(1, dim_size)  
     index = torch.randint(0, dim_size, index_shape).cuda()
 
-    mod = FuncModule(torch.ops.aten.gather.default, dim=dim, index=index).cuda()
+    mod = GatherModule(op_alias, dim).cuda()
 
-    mgx_mod = convert_to_mgx(mod, [input])
-    verify_outputs(mod, mgx_mod, input)
+    mgx_mod = convert_to_mgx(mod, [input, index])
+    verify_outputs(mod, mgx_mod, [input, index])

--- a/tests/fx/converters/test_gather_fx.py
+++ b/tests/fx/converters/test_gather_fx.py
@@ -3,6 +3,15 @@ import torch
 import numpy as np
 from fx_test_utils import FuncModule, convert_to_mgx, verify_outputs
 
+class GatherModule(torch.nn.Module):
+
+    def __init__(self, dim):
+        super(GatherModule, self).__init__()
+        self.dim = dim
+
+    def forward(self, x, idx):
+        return torch.gather(x, self.dim, idx)
+
 @pytest.mark.parametrize("input_dim, dim", [((3, 3), 0), 
                                             ((3, 3), 1), 
                                             ((3, 3), -1), 
@@ -18,7 +27,7 @@ def test_gather(input_dim, dim):
     index_shape[dim] = np.random.randint(1, dim_size)  
     index = torch.randint(0, dim_size, index_shape)
 
-    mod = FuncModule(torch.gather, dim=dim, index=index).cuda()
+    mod = GatherModule(dim)
 
-    mgx_mod = convert_to_mgx(mod, [input])
-    verify_outputs(mod, mgx_mod, input)
+    mgx_mod = convert_to_mgx(mod, [input, index])
+    verify_outputs(mod, mgx_mod, [input, index])


### PR DESCRIPTION
currently when the gather dim is the first or last dimension, its causing following bad literals to be added to the migraphx program:
`@0 = @literal{211585604} -> int64_type, {4, 0}, {0, 1}`
Sometimes this still gets through compile fine, but its causing issues in some huggingface models: PLBartForConditionalGeneration, XGLMForCausalLM, MBartForConditionalGeneration

This fixes the listed models