### PR TITLE
skip tests based on gpu arch

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,12 @@ def torch_version():
     return torch.__version__
 
 
+@pytest.fixture()
+def gpu_arch():
+    return torch.cuda.get_device_properties(
+        torch.cuda.current_device()).gcnArchName.split(":")[0]
+
+
 @pytest.fixture(autouse=True)
 def skip_min_migraphx_version(request, migraphx_version):
     if request.node.get_closest_marker('skip_min_migraphx_ver'):
@@ -45,9 +51,17 @@ def skip_min_migraphx_version(request, migraphx_version):
 @pytest.fixture(autouse=True)
 def skip_min_torch_version(request, torch_version):
     if request.node.get_closest_marker('skip_min_torch_ver'):
-        min_ver = request.node.get_closest_marker(
-            'skip_min_torch_ver').args[0]
+        min_ver = request.node.get_closest_marker('skip_min_torch_ver').args[0]
         if version.parse(torch_version) < version.parse(min_ver):
             pytest.skip(
                 f"Skipping because found Torch version {torch_version} < {min_ver}"
             )
+
+
+@pytest.fixture(autouse=True)
+def skip_unsupported_arch(request, gpu_arch):
+    if request.node.get_closest_marker('supported_gpu_arch'):
+        supported_arches = request.node.get_closest_marker(
+            'supported_gpu_arch').args[0]
+        if gpu_arch not in supported_arches:
+            pytest.skip(f"Skipping because test not supported on {gpu_arch}")

--- a/tests/dynamo/converters/test_attn_dynamo.py
+++ b/tests/dynamo/converters/test_attn_dynamo.py
@@ -3,24 +3,34 @@ import torch
 from dynamo_test_utils import FuncModule, FuncModuleFirstOut, convert_to_mgx, verify_outputs
 import random
 
+
 @pytest.mark.parametrize('op_alias', [
-    pytest.param(torch.ops.aten._scaled_dot_product_flash_attention.default, 
-                 marks=pytest.mark.skip_min_torch_ver("2.3"))
+    pytest.param(torch.ops.aten._scaled_dot_product_flash_attention.default,
+                 marks=[
+                     pytest.mark.skip_min_torch_ver("2.3"),
+                     #TODO: see if better way to pull this info from some torch API
+                     pytest.mark.supported_gpu_arch(
+                         ["gfx940", "gfx941", "gfx942", "gfx94a", "gfx90a"])
+                 ])
 ])
-@pytest.mark.parametrize('qkv_shape, is_causal, scale', 
-                         [
-                          ((2, 1, 5, 64), False, None),
-                          ((2, 1, 5, 64), True, None),
-                          ((2, 1, 5, 64), False, 0.5),
-                          ((2, 1, 5, 64), True, 0.25), 
-                          ])
+@pytest.mark.parametrize('qkv_shape, is_causal, scale', [
+    ((2, 1, 5, 64), False, None),
+    ((2, 1, 5, 64), True, None),
+    ((2, 1, 5, 64), False, 0.5),
+    ((2, 1, 5, 64), True, 0.25),
+])
 def test_attn(op_alias, qkv_shape, is_causal, scale):
 
     query = torch.randn(qkv_shape).to(torch.float16).cuda()
     key = torch.randn(qkv_shape).to(torch.float16).cuda()
     value = torch.randn(qkv_shape).to(torch.float16).cuda()
 
-    mod = FuncModuleFirstOut(op_alias, key=key, value=value, dropout_p=0.0, is_causal=is_causal, scale=scale).cuda() 
+    mod = FuncModuleFirstOut(op_alias,
+                             key=key,
+                             value=value,
+                             dropout_p=0.0,
+                             is_causal=is_causal,
+                             scale=scale).cuda()
 
     mgx_mod = convert_to_mgx(mod, [query])
     verify_outputs(mod, mgx_mod, query)


### PR DESCRIPTION
Only test `aten._scaled_dot_product_flash_attention` explicitly on supported (by pytorch) gpus