### PR TITLE
update normalization to simply use reduce_mean

### DIFF
--- a/py/torch_migraphx/fx/converters/acc_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/acc_ops_converters.py
@@ -2023,17 +2023,8 @@ def compute_norm(mgx_module, x, eps, axes):
     mean_mgx = mgx_module.add_instruction(
         migraphx.op('multibroadcast', out_lens=out_shape), [mean_mgx])
     sub_mgx = mgx_module.add_instruction(migraphx.op('sub'), [x, mean_mgx])
-
-    num_reduce_elems = torch.tensor(out_shape)[axes].prod().sqrt().item()
-    sqrt_elems_mgx = mgx_module.add_literal(
-        torch.tensor(num_reduce_elems, dtype=dtype).numpy())
-    sqrt_elems_mgx = mgx_module.add_instruction(
-        migraphx.op('multibroadcast', out_lens=out_shape), [sqrt_elems_mgx])
-    div_sub_mgx = mgx_module.add_instruction(migraphx.op('div'),
-                                             [sub_mgx, sqrt_elems_mgx])
-    pow_mgx = mgx_module.add_instruction(migraphx.op('mul'),
-                                         [div_sub_mgx, div_sub_mgx])
-    var_mgx = mgx_module.add_instruction(migraphx.op('reduce_sum', axes=axes),
+    pow_mgx = mgx_module.add_instruction(migraphx.op('mul'), [sub_mgx, sub_mgx])
+    var_mgx = mgx_module.add_instruction(migraphx.op('reduce_mean', axes=axes),
                                          [pow_mgx])
 
     var_mgx = mgx_module.add_instruction(


### PR DESCRIPTION
There was some logic for variance calculation for reducing chance of overflow. That is no longer needed, migraphx compile can handle this better.