### PR TITLE
Improve configuration and fix __version__ check

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,22 @@ Install Pre-reqs:
 - [MIGraphX](https://github.com/ROCm/AMDMIGraphX?tab=readme-ov-file#installing-from-binaries)
 
 Build and install from source
+
+If you wish to set a custom path for your cmake install
+
+```bash
+export CMAKE_BIN=/path/to/my/cmake
 ```
+
+If you wish to set a custom number of processes for building (otherwise all will be used).
+
+```bash
+export CMAKE_BIN=/path/to/my/cmake
+```
+
+Then to install
+
+```bash
 git clone https://github.com/ROCmSoftwarePlatform/torch_migraphx.git
 cd ./torch_migraphx/py
 export TORCH_CMAKE_PATH=$(python -c "import torch; print(torch.utils.cmake_prefix_path)")

--- a/py/setup.py
+++ b/py/setup.py
@@ -93,8 +93,11 @@ class CMakeBuild(build_ext):
             build_args += ['--', '/m']
         else:
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
-            # TODO: find # of procs
-            build_args += ['--', '-j2']
+            if os.environ.get("NPROCS"):
+                build_args += ['--', '-j' + os.environ["NPROCS"]]
+            else:
+                nprocs = os.sysconf('SC_NPROCESSORS_ONLN')
+                build_args += ['--', '-j' + str(nprocs)]
 
         env = os.environ.copy()
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(

--- a/py/setup.py
+++ b/py/setup.py
@@ -55,7 +55,8 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     def run(self):
         try:
-            out = subprocess.check_output(['cmake', '--version'])
+            cmake_bin = os.environ.get("CMAKE_BIN", "cmake")
+            out = subprocess.check_output([cmake_bin, '--version'])
         except OSError:
             raise RuntimeError(
                 "CMake must be installed to build the following extensions: " +

--- a/py/setup.py
+++ b/py/setup.py
@@ -46,6 +46,8 @@ if not TORCH_CMAKE_PATH:
     import torch
     TORCH_CMAKE_PATH = torch.utils.cmake_prefix_path
 
+CMAKE_BIN = os.environ.get("CMAKE_BIN", "cmake")
+
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=''):
         Extension.__init__(self, name, sources=[])
@@ -55,8 +57,7 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     def run(self):
         try:
-            cmake_bin = os.environ.get("CMAKE_BIN", "cmake")
-            out = subprocess.check_output([cmake_bin, '--version'])
+            out = subprocess.check_output([CMAKE_BIN, '--version'])
         except OSError:
             raise RuntimeError(
                 "CMake must be installed to build the following extensions: " +
@@ -104,10 +105,10 @@ class CMakeBuild(build_ext):
             env.get('CXXFLAGS', ''), self.distribution.get_version())
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
-        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args,
+        subprocess.check_call([CMAKE_BIN, ext.sourcedir] + cmake_args,
                               cwd=self.build_temp,
                               env=env)
-        subprocess.check_call(['cmake', '--build', '.'] + build_args,
+        subprocess.check_call([CMAKE_BIN, '--build', '.'] + build_args,
                               cwd=self.build_temp)
 
         print()

--- a/py/torch_migraphx/fx/converter_registry.py
+++ b/py/torch_migraphx/fx/converter_registry.py
@@ -32,7 +32,10 @@ import migraphx
 
 # For old MIGraphX dev builds, there is no way to obtain proper version information
 # default this to 2.10 because this issue is resolved from 2.11.0 and onward
-MIGRAPHX_VERSION = migraphx.__version__ if migraphx.__version__ != "dev" else "2.10"
+try:
+    MIGRAPHX_VERSION = migraphx.__version__ if migraphx.__version__ != "dev" else "2.10"
+except:
+    MIGRAPHX_VERSION = "2.10"
 
 CONVERTERS = {}
 


### PR DESCRIPTION
1. Correcting incorrect version check

On older builds of MIGraphX, there is no __version__ method for the module. The current way that the MIGRAPHX_VERSION constant is set does not work with this

https://github.com/ROCm/torch_migraphx/blob/fb03721196bdb9810d5a99f4d24573a77f2d60b8/py/torch_migraphx/fx/converter_registry.py#L35

As, since the module has no __version__, this ternary first checks the module version, and fails. Adding a try except here corrects this and implements the intended behavior, that is, to default to 2.10 if there is not version info.

This fixes #244 

2. Improve configurability of setup.py

Currently, setup.py uses whatever the default `cmake` is on the system. For certain environments, this is not ideal or does not exist. To easily set the cmake path, the CMAKE_BIN env var can now be set to configure the cmake that is used for building. If this is not set, the old default cmake behavior is preserved.

Additionally, the script previously used a default of `-j2` for compilation with a TODO for implementing a method for getting nprocs. This has been implemented with SC_NPROCESSORS_ONLN which is available for all posix systems. If the user wishes to set a number of processes less than this number, they can set the NPROCS environment variable.