### PR TITLE
disable unstable efficient attn tests

### DIFF
--- a/py/torch_migraphx/fx/converters/aten_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/aten_ops_converters.py
@@ -1316,6 +1316,10 @@ def aten_ops_scaled_dot_product_attention(mgx_module, node, args, kwargs):
 
     if len(args) >= 4:
         acc_kwargs["attn_bias"] = args[3]
+        logging.warning("The op `aten._scaled_dot_product_efficient_attention.default` is called with "
+        "attn_bias defined. The behavior of this is not stable between PyTorch versions and may result "
+        "in accuracy problems. Consider setting Torch sdpa to use MATH or FLASH algorithms as a workaround. "
+        "See https://pytorch.org/docs/stable/generated/torch.nn.attention.sdpa_kernel.html")
     if len(args) >= 7:
         acc_kwargs["is_causal"] = args[6]
 

--- a/tests/dynamo/converters/test_attn_dynamo.py
+++ b/tests/dynamo/converters/test_attn_dynamo.py
@@ -23,9 +23,9 @@ class AttnMod(FuncModule):
             ])
     ])
 @pytest.mark.parametrize('qkv_shape, is_causal, scale', [
-    ((2, 1, 5, 64), False, None),
-    ((2, 1, 5, 64), True, None),
-    ((2, 1, 5, 64), False, 0.5),
+    ((2, 1, 5, 8), False, None),
+    ((2, 3, 5, 16), True, None),
+    ((2, 2, 5, 32), False, 0.5),
     ((2, 1, 5, 64), True, 0.25),
 ])
 def test_attn_flash(op_alias, qkv_shape, is_causal, scale):
@@ -55,8 +55,12 @@ def test_attn_flash(op_alias, qkv_shape, is_causal, scale):
     ])
 @pytest.mark.parametrize('qkv_shape, is_causal, scale, bias', [
     ((2, 3, 5, 16), False, None, False),
-    ((2, 3, 5, 9), True, None, True),
-    ((4, 3, 5, 12), False, 0.5, True),
+    # Disabling bias parameter as attn_bias is not defined as an input in the 
+    # high level API and no good documentation exists on the behavior of this
+    # low level aten op for this parameter 
+    # https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html
+    # ((1, 3, 5, 9), True, None, True),
+    # ((4, 3, 5, 12), False, 0.5, True),
     ((5, 3, 5, 10), True, 0.25, False),
 ])
 def test_attn_efficient(op_alias, qkv_shape, is_causal, scale, bias):


### PR DESCRIPTION
Doc for high level op: https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html

The behavior of `attn_bias` parameter for `aten._scaled_dot_product_efficient_attention` is not consistent between pytorch versions and also not well documented. For most use cases this optional parameter is not set and for use cases where this is an issue, it is better to provide a workaround in the warning message.