### PR TITLE
add pass to remove aot assertion nodes during dynamo lowering

### DIFF
--- a/py/torch_migraphx/dynamo/passes/pass_manager.py
+++ b/py/torch_migraphx/dynamo/passes/pass_manager.py
@@ -31,7 +31,7 @@ import os
 import torch
 from torch.fx.passes.pass_manager import PassManager
 
-from .remove_ops import remove_const_ops, remove_view_ops
+from .remove_ops import remove_const_ops, remove_view_ops, remove_assert_ops
 from .rewrite_complex_ops import rewrite_complex_ops
 from .const_fold import const_fold
 from .promote_types import promote_inputs
@@ -54,6 +54,7 @@ class MGXPassManager(PassManager):
 
 def pre_partition_pass(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
     passes = [
+        remove_assert_ops,
         remove_const_ops,
         remove_view_ops,
         promote_inputs,

--- a/py/torch_migraphx/dynamo/passes/remove_ops.py
+++ b/py/torch_migraphx/dynamo/passes/remove_ops.py
@@ -39,6 +39,30 @@ if DYNAMO_LOGLEVEL:
 
 
 @log_pass(_LOGGER, logging.DEBUG)
+def remove_assert_ops(gm: torch.fx.GraphModule):
+    """Remove no-op assert/metadata guard nodes inserted by torch.export.
+
+    PyTorch (>=2.6) inserts guard ops such as
+    ``aten._assert_tensor_metadata`` (recording a tensor's dtype/device/layout
+    around dtype conversions) and ``aten._assert_scalar``. These are Python-side
+    contracts with no MIGraphX equivalent. They return ``None`` and have no data
+    dependents, so they are safe to erase.
+    """
+    assert_ops = []
+    for op_name in ("_assert_tensor_metadata", "_assert_scalar"):
+        op = getattr(torch.ops.aten, op_name, None)
+        if op is not None and hasattr(op, "default"):
+            assert_ops.append(op.default)
+
+    for node in list(gm.graph.nodes):
+        if node.op == "call_function" and node.target in assert_ops:
+            gm.graph.erase_node(node)
+    gm.graph.eliminate_dead_code()
+    gm.recompile()
+    return gm
+
+
+@log_pass(_LOGGER, logging.DEBUG)
 def remove_clone_ops(gm: torch.fx.GraphModule):
     clone_ops = [
         torch.ops.aten.clone.default,


### PR DESCRIPTION
## Motivation

Newer pytorch versions' `aot_export_joint_simple` adds assertion nodes that cause issues when lowering.

## Technical Details

Add pass to remove these nodes before const-folding and lowering to migraphx IR
