### PR TITLE
Fix import for torch>=2.12: quantize_pt2e removed

### DIFF
--- a/py/torch_migraphx/fx/converters/quant_ops_converters.py
+++ b/py/torch_migraphx/fx/converters/quant_ops_converters.py
@@ -45,8 +45,13 @@ from ..utils import (
 from ..mgx_module import MGXInstruction
 from torch_migraphx.fx.converters import acc_ops_converters
 
-# Import required to populate torch.ops.quantized_decomposed
-import torch.ao.quantization.quantize_pt2e
+# Import required to populate torch.ops.quantized_decomposed.
+# torch>=2.12 removed torch.ao.quantization.quantize_pt2e; the quantized_decomposed ops are now
+# registered by torch.ao.quantization.fx._decomposed instead.
+try:
+    import torch.ao.quantization.quantize_pt2e  # noqa: F401  (torch < 2.12)
+except ModuleNotFoundError:
+    import torch.ao.quantization.fx._decomposed  # noqa: F401  (torch >= 2.12)
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Fix `import torch_migraphx` on torch >= 2.12 (`quantize_pt2e` removed)

### Problem
`import torch_migraphx` fails for **all** users on recent PyTorch, not only those doing quantization:

```
File ".../fx/converters/quant_ops_converters.py", line 49, in <module>
    import torch.ao.quantization.quantize_pt2e
ModuleNotFoundError: No module named 'torch.ao.quantization.quantize_pt2e'
```

The module was deleted in [pytorch/pytorch#169151](https://github.com/pytorch/pytorch/pull/169151)
("Delete pt2e flow… migrated to torchao", merged `0e38e02`), which ships in the torch 2.9+ line —
matching the report in #279 (torch 2.9.1) and reproduced here on torch 2.12.1.

Note the import exists purely for a **side effect**: registering the `torch.ops.quantized_decomposed`
ops used by the converter decorators just below it. Guarding the import alone is not enough — the
module then fails at decorator time with
`'_OpNamespace' 'quantized_decomposed' object has no attribute 'quantize_per_tensor'`.

### Fix
The two layers PyTorch split apart matter here:
- The **pt2e *flow*** (`prepare_pt2e`/`convert_pt2e`) moved to torchao — that's what #169151 deleted.
- The **`quantized_decomposed` *ops*** remain in torch core, registered by
  `torch.ao.quantization.fx._decomposed`.

This import only needs the latter, so pointing it at `fx._decomposed` is the canonical, in-core,
zero-dependency registrar (not a workaround). Guarded for back-compat with torch < 2.12:

```python
# Import required to populate torch.ops.quantized_decomposed.
try:
    import torch.ao.quantization.quantize_pt2e        # torch < 2.12
except ModuleNotFoundError:
    import torch.ao.quantization.fx._decomposed       # torch >= 2.12
```

One file changed; no behavioral change on older torch (it takes the `try` path unchanged).

### Verification
Verified on **torch 2.12.1+rocm7.2** (HIP 7.2), ROCm 7.2.4, Radeon RX 7900 XTX (gfx1100), Linux:
- `import torch_migraphx` succeeds; the `migraphx` dynamo backend loads.
- `torch.ops.quantized_decomposed` is populated (`quantize_per_tensor` etc. present).
- `torch.compile(model, backend="migraphx")` runs a conv+linear model and ResNet-50, output matching
  eager to fp32 epsilon (max |Δ| ≈ 1.2e-7).

`fx._decomposed` has existed across the affected range, so the same guard covers the torch 2.9.1
case reported in #279 (Windows / gfx1151) as well as torch 2.12 here.

### Scope
This restores import + the existing `quantized_decomposed` converters only. Fully migrating
torch_migraphx's pt2e quantization *flow* to torchao is a separate, larger change and out of scope here.

Fixes #279
